### PR TITLE
add promo code to WEB and API

### DIFF
--- a/src/integrations/api/client.ts
+++ b/src/integrations/api/client.ts
@@ -180,6 +180,7 @@ export const authAPI = {
     profileImageUrl: string;
     lastKnownIp: string;
     redirect?: string;
+    promoCode?: string;
   }) => {
     const response = await apiClient.post('/auth/register', userData);
     return response.data;

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -37,6 +37,7 @@ export default function SignUp() {
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [promoCode, setPromoCode] = useState('');
   const [tosAccepted, setTosAccepted] = useState(false);
   const [isOlder, setIsOlder] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -85,6 +86,7 @@ export default function SignUp() {
     isOlder: z.boolean().refine(val => val === true, {
       message: 'You must be atleast 18 years old',
     }),
+    promoCode: z.string().optional(),
   });
 
   const form = useForm({
@@ -93,6 +95,7 @@ export default function SignUp() {
       username: '',
       email: '',
       password: '',
+      promoCode: '',
       dob: undefined,
       tosAccepted: false,
       isOlder: false,
@@ -116,6 +119,7 @@ export default function SignUp() {
       profileImageUrl: string;
       lastKnownIp: string;
       redirect?: string;
+      promoCode?: string;
     }) => {
       // Verify location again before proceeding with signup
       const locationResult = await verifyUserLocation();
@@ -195,16 +199,17 @@ export default function SignUp() {
     if (username) validateField('username', username);
     if (email) validateField('email', email);
     if (password) validateField('password', password);
+    if (promoCode) validateField('promoCode', promoCode);
     if (tosAccepted) validateField('tosAccepted', tosAccepted);
     if (isOlder) validateField('isOlder', isOlder);
     if (dob) validateField('dob', dob);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasSubmitted, username, email, password, tosAccepted, isOlder, dob]);
+  }, [hasSubmitted, username, email, password, promoCode, tosAccepted, isOlder, dob]);
 
   const validateForm = () => {
     setHasSubmitted(true);
     try {
-      signupSchema.parse({ username, email, password, dob, tosAccepted, isOlder });
+      signupSchema.parse({ username, email, password, promoCode, dob, tosAccepted, isOlder });
       setErrors({});
       return true;
     } catch (error) {
@@ -301,6 +306,7 @@ export default function SignUp() {
       profileImageUrl: profileImageUrl || undefined,
       lastKnownIp: locationResult?.ip_address,
       redirect: redirectParam || undefined,
+      promoCode: promoCode || undefined,
     });
   };
 
@@ -572,6 +578,19 @@ export default function SignUp() {
                       Password must be at least 8 characters and include uppercase, lowercase,
                       number, and special character.
                     </p>
+                  </motion.div>
+                  <motion.div variants={itemVariants} className="space-y-2">
+                    <Label htmlFor="promoCode">Promo Code (Optional)</Label>
+                    <Input
+                      id="promoCode"
+                      type="text"
+                      value={promoCode}
+                      placeholder="Enter promo code (optional)"
+                      onChange={e => setPromoCode(e.target.value)}
+                      className={`bg-[#272727]/80 text-white placeholder:rgba(255, 255, 255, 1) ${errors.promoCode ? 'border-destructive' : ''} border-0 focus:border-0 focus:ring-0`}
+                      disabled={isCheckingLocation || (locationResult && !locationResult.allowed)}
+                    />
+                    {errors.promoCode && <p className="text-destructive text-sm">{errors.promoCode}</p>}
                   </motion.div>
                   <motion.div variants={itemVariants} className="space-y-2">
                     <Label htmlFor="dob">Date of Birth</Label>


### PR DESCRIPTION
This pull request adds support for an optional promo code field to the user sign-up flow. The changes ensure that the promo code can be entered, validated, and submitted as part of the registration process, both in the frontend form and the API request.

**Sign-up form enhancements:**

* Added a new `promoCode` state variable and input field to the sign-up form, allowing users to optionally enter a promo code during registration. [[1]](diffhunk://#diff-2fe7abbeeb3ff15906dc01d1e8df3ffd9bb2127f304a812bf11d3e1ff90314f4R40) [[2]](diffhunk://#diff-2fe7abbeeb3ff15906dc01d1e8df3ffd9bb2127f304a812bf11d3e1ff90314f4R582-R594)
* Updated the form validation schema and logic to include the optional `promoCode` field, ensuring it is properly validated if provided. [[1]](diffhunk://#diff-2fe7abbeeb3ff15906dc01d1e8df3ffd9bb2127f304a812bf11d3e1ff90314f4R89) [[2]](diffhunk://#diff-2fe7abbeeb3ff15906dc01d1e8df3ffd9bb2127f304a812bf11d3e1ff90314f4R202-R212)

**API integration updates:**

* Modified the registration API request to include the `promoCode` field when present, both in the frontend handler and in the API client. [[1]](diffhunk://#diff-2fe7abbeeb3ff15906dc01d1e8df3ffd9bb2127f304a812bf11d3e1ff90314f4R122) [[2]](diffhunk://#diff-2fe7abbeeb3ff15906dc01d1e8df3ffd9bb2127f304a812bf11d3e1ff90314f4R309) [[3]](diffhunk://#diff-5da9525b80e737f8309b545d662efffd75ca1dfaa50ab3695364b081c8460173R183)

**Form initialization:**

* Updated the form's initial values to include `promoCode`, ensuring consistent state management.