### PR TITLE
Update terminology from "Sweep Coins" to "Stream Coins" 

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>Streambet</title>
-    <meta name="description" content="StreamBet - Live video picking" />
+    <meta name="description" content="StreamBet - Live video picks" />
     <meta name="author" content="StreamBet" />
     
     <!-- Open Graph / Social Media sharing tags -->
-    <meta property="og:title" content="StreamBet - Live video picking" />
+    <meta property="og:title" content="StreamBet - Live video picks" />
     <meta property="og:description" content="Pick on live streams in real-time with StreamBet" />
     <meta property="og:image" content="/lovable-uploads/socialshare.png" />
     <meta property="og:url" content="https://streambet.lovable.app" />
@@ -16,7 +16,7 @@
     
     <!-- Twitter Card tags -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="StreamBet - Live video picking" />
+    <meta name="twitter:title" content="StreamBet - Live video picks" />
     <meta name="twitter:description" content="Pick on live streams in real-time with StreamBet" />
     <meta name="twitter:image" content="/lovable-uploads/f073d284-30de-4f35-aa05-ad54421c736d.png" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />

--- a/src/components/StreamCard.tsx
+++ b/src/components/StreamCard.tsx
@@ -218,7 +218,7 @@ export const StreamCard = ({
                     <LockKeyholeOpen className="h-3 w-3" />
                   ) : null}
                   <span>
-                    {isBettingLocked ? 'Picking Locked' : isBettingOpen ? 'Picking Open' : ''}
+                    {isBettingLocked ? 'Picks Locked' : isBettingOpen ? 'Picks Open' : ''}
                   </span>
                 </div>
               )}

--- a/src/components/WalletHistory.tsx
+++ b/src/components/WalletHistory.tsx
@@ -120,7 +120,7 @@ export const WalletHistory: React.FC<Props> = ({ historyType }) => {
                     </Card>
                   ))
               : paginatedUsers?.length === 0
-                ? (<div className="text-center py-6 text-muted-foreground text-base">No picking history found</div>)
+                ? (<div className="text-center py-6 text-muted-foreground text-base">No picks history found</div>)
                 : paginatedUsers?.map(user => (
                     <Card key={user.id} className="bg-[#181A20] border border-[#23272F] rounded-lg shadow-sm">
                       <CardContent className="p-3 space-y-2">
@@ -224,7 +224,7 @@ export const WalletHistory: React.FC<Props> = ({ historyType }) => {
                   {paginatedUsers?.length === 0 ? (
                     <TableRow>
                       <TableCell colSpan={9} className="text-center py-6 text-muted-foreground">
-                        No picking history found matching
+                        No picks history found matching
                       </TableCell>
                     </TableRow>
                   ) : (

--- a/src/components/WalletHistory.tsx
+++ b/src/components/WalletHistory.tsx
@@ -112,7 +112,7 @@ export const WalletHistory: React.FC<Props> = ({ historyType }) => {
                           <div className="flex justify-between items-center">
                             <span className="text-xs text-muted-foreground">Amount</span>
                             <span className="text-xs font-semibold" style={{ color: user?.amount > 0 ? '#7AFF14' : user?.amount < 0 ? '#FF5656' : undefined }}>
-                              {user?.amount < 0 ? '-' : ''}{Math.abs(user?.amount ?? 0)?.toLocaleString('en-US')}{user?.currencytype === CurrencyType.SWEEP_COINS ? ' Sweep Coin(s)' : ' Gold Coin(s)'}
+                              {user?.amount < 0 ? '-' : ''}{Math.abs(user?.amount ?? 0)?.toLocaleString('en-US')}{user?.currencytype === CurrencyType.SWEEP_COINS ? ' Stream Coin(s)' : ' Gold Coin(s)'}
                             </span>
                           </div>
                         </div>
@@ -145,7 +145,7 @@ export const WalletHistory: React.FC<Props> = ({ historyType }) => {
                           </div>
                           <div className="flex justify-between items-center">
                             <span className="text-xs text-muted-foreground">Coin Type</span>
-                            <span className="text-xs font-medium">{user?.coinType === CurrencyType.GOLD_COINS ? 'Gold coins' : 'Sweep coins'}</span>
+                            <span className="text-xs font-medium">{user?.coinType === CurrencyType.GOLD_COINS ? 'Gold coins' : 'Stream Coins'}</span>
                           </div>
                           <div className="flex justify-between items-center">
                             <span className="text-xs text-muted-foreground">Amount</span>
@@ -197,7 +197,7 @@ export const WalletHistory: React.FC<Props> = ({ historyType }) => {
                         <TableCell className="text-left">{user?.type}</TableCell>
                         <TableCell className="text-right">
                           <span style={{ color: user?.amount > 0 ? '#7AFF14' : user?.amount < 0 ? '#FF5656' : undefined }}>
-                            {user?.amount < 0 ? '-' : ''}{Math.abs(user?.amount ?? 0)?.toLocaleString('en-US')}{user?.currencytype === CurrencyType.SWEEP_COINS ? ' Sweep Coin(s)' : ' Gold Coin(s)'}
+                            {user?.amount < 0 ? '-' : ''}{Math.abs(user?.amount ?? 0)?.toLocaleString('en-US')}{user?.currencytype === CurrencyType.SWEEP_COINS ? ' Stream Coin(s)' : ' Gold Coin(s)'}
                           </span>
                         </TableCell>
                       </TableRow>
@@ -234,7 +234,7 @@ export const WalletHistory: React.FC<Props> = ({ historyType }) => {
                         <TableCell className="text-[14px] text-left">{user?.streamName}</TableCell>
                         <TableCell className="text-[14px] text-left">{user?.roundName}</TableCell>
                         <TableCell className="text-[14px] text-left">{user?.optionName}</TableCell>
-                        <TableCell className="text-[14px] text-left">{user?.coinType === CurrencyType.GOLD_COINS ? 'Gold coins' : 'Sweep coins'}</TableCell>
+                        <TableCell className="text-[14px] text-left">{user?.coinType === CurrencyType.GOLD_COINS ? 'Gold coins' : 'Stream Coins'}</TableCell>
                         <TableCell className="text-[14px] text-left">{Math.abs(user?.amountPlaced ?? 0)?.toLocaleString('en-US')}</TableCell>
                         <TableCell className="text-[16px] text-left">
                           <span className="px-2 py-1 bg-[#2C2C2C] rounded-md">

--- a/src/components/admin/AdminBettingRoundsCard.tsx
+++ b/src/components/admin/AdminBettingRoundsCard.tsx
@@ -163,7 +163,7 @@ export const AdminBettingRoundsCard = ({
                     <CardHeader
                          className="flex flex-row items-center justify-between h-[50px] rounded-t-xl px-6 py-0 bg-[#000000B2]"
                     >
-                         <span className="font-medium [color:rgba(215,223,239,1)] text-lg">Picking Rounds</span>
+                         <span className="font-medium [color:rgba(215,223,239,1)] text-lg">Rounds</span>
                          {!isStreamEnded && <Dialog open={settingsOpen} onOpenChange={(open) => {
                               setSettingsOpen(open);
                               if (!open) {
@@ -186,7 +186,7 @@ export const AdminBettingRoundsCard = ({
                                         onMouseOver={e => (e.currentTarget.style.color = '#000')}
                                         onMouseOut={e => (e.currentTarget.style.color = '')}
                                    >
-                                        Picking Settings
+                                        Picks Settings
                                    </Button>
                               </DialogTrigger>
                               <DialogContent className="max-w-2xl winner-scrollbar p-0 border border-primary no-dialog-close">
@@ -204,7 +204,7 @@ export const AdminBettingRoundsCard = ({
                                         {/* Header row: label, Save button */}
                                         <div className="flex items-center mb-4">
                                              <div className="flex-1 flex items-center justify-between">
-                                                  <span className="text-white font-medium" style={{ fontWeight: 500, fontSize: 18 }}>Picking Settings</span>
+                                                  <span className="text-white font-medium" style={{ fontWeight: 500, fontSize: 18 }}>Picks Settings</span>
                                                   <Button
                                                        type="button"
                                                        className="bg-primary text-black font-bold px-6 py-2 rounded-lg shadow-none border-none w-[120px] h-[40px]"
@@ -381,7 +381,7 @@ export const AdminBettingRoundsCard = ({
                                                                            className="text-center mb-2 text-white text-base font-bold"
                                                                            style={{ fontFamily: 'FabioXM, Inter, sans-serif', fontWeight: 700 }}
                                                                       >
-                                                                           Users are picking
+                                                                           Users are making their picks
                                                                       </div>
                                                                      <div className="flex items-center gap-3 mb-2">
                                                                            <div className=" items-center gap-1">
@@ -613,7 +613,7 @@ export const AdminBettingRoundsCard = ({
                                              );
                                         }) : (
                                              <div className="w-full flex items-center justify-center h-32 text-white/60 text-lg">
-                                                  No picking rounds available.
+                                                  No picks rounds available.
                                              </div>
                                         )}
                                    </CarouselContent>

--- a/src/components/admin/AdminBettingRoundsCard.tsx
+++ b/src/components/admin/AdminBettingRoundsCard.tsx
@@ -397,7 +397,7 @@ export const AdminBettingRoundsCard = ({
                                                                            <div className=" items-center gap-2">
                                                                            <div className="flex items-center gap-1 mb-2 text-white text-sm font-medium">
                                                                                 <img src="/icons/Users.svg" alt="Users" className="w-4 h-4" />
-                                                                                <span>{bettingUpdate ? bettingUpdate?.totalSweepCoinBet : streamInfo?.totalSweepCoinBet} sweep(s)</span>
+                                                                                <span>{bettingUpdate ? bettingUpdate?.totalSweepCoinBet : streamInfo?.totalSweepCoinBet} Stream Coin(s)</span>
                                                                            </div>
                                                                            <div className="flex items-center gap-1 text-yellow-400 text-sm font-medium">
                                                                                 <img src="/icons/coin.svg" alt="Coins" className="w-4 h-4" />
@@ -571,9 +571,9 @@ export const AdminBettingRoundsCard = ({
                                                                                 </div>
                                                                                 <div className="flex items-center mt-1 text-[12px] px-2" style={FabioBoldStyle}>
                                                                                      <span className="text-white ml-1">won</span>
-                                                                                     <span className="text-white ml-1 truncate max-w-[120px]" title={isSweepCoins ? `${Number(round?.winnerAmount?.sweepCoins || 0)?.toLocaleString('en-US')} sweep coins` 
+                                                                                     <span className="text-white ml-1 truncate max-w-[120px]" title={isSweepCoins ? `${Number(round?.winnerAmount?.sweepCoins || 0)?.toLocaleString('en-US')} Stream Coins` 
                                                                                      : `${Number(round?.winnerAmount?.goldCoins || 0)?.toLocaleString('en-US')} gold coins`}>
-                                                                                          {isSweepCoins ? `${Number(round?.winnerAmount?.sweepCoins || 0)?.toLocaleString('en-US')} sweep coins` 
+                                                                                          {isSweepCoins ? `${Number(round?.winnerAmount?.sweepCoins || 0)?.toLocaleString('en-US')} Stream Coins` 
                                                                                           : `${Number(round?.winnerAmount?.goldCoins || 0)?.toLocaleString('en-US')} gold coins`}
                                                                                      </span>
                                                                                 </div>

--- a/src/components/admin/AdminManagement.tsx
+++ b/src/components/admin/AdminManagement.tsx
@@ -114,7 +114,7 @@ export const AdminManagement = ({
         ? api.admin.updateBettingData(payload)
         : api.admin.createBettingData(payload),
     onSuccess: () => {
-      toast({ title: 'Success', description: 'Stream and Picking saved successfully!' });
+      toast({ title: 'Success', description: 'Stream and Picks saved successfully!' });
       handleResetAll();
     },
     onError: (error: any) => {

--- a/src/components/admin/BettingRounds.tsx
+++ b/src/components/admin/BettingRounds.tsx
@@ -283,7 +283,7 @@ export function BettingRounds({
                           <div className="flex items-center justify-center h-full" style={{ minHeight: 57 }}>
                             <DeleteBettingDialog
                               title="Delete Round"
-                              message={`Deleting this round will delete all picking options related with this round. Are you sure?`}
+                              message={`Deleting this round will delete all picks options related with this round. Are you sure?`}
                               onConfirm={() => deleteRound(roundIndex)}
                               isNotCreatedStatus={isNotCreatedStatus}
                             />
@@ -423,7 +423,7 @@ export function BettingRounds({
         </div>
       ) : (
         <div className="text-center py-8 text-gray-500">
-          No picking rounds created yet. Click "+ New round" to get started.
+          No picks rounds created yet. Click "+ New round" to get started.
         </div>
       )}
        {createStream ? (

--- a/src/components/admin/StreamTable.tsx
+++ b/src/components/admin/StreamTable.tsx
@@ -221,7 +221,7 @@ export const StreamTable: React.FC<Props> = ({
 
                   {/* Betting Status */}
                   <div className="flex justify-between items-center">
-                    <span className="text-sm text-muted-foreground">Picking Status:</span>
+                    <span className="text-sm text-muted-foreground">Picks Status:</span>
                     <BettingStatusBadge status={stream?.bettingRoundStatus || 'N/A'} />
                   </div>
 
@@ -306,7 +306,7 @@ export const StreamTable: React.FC<Props> = ({
               <TableRow>
                 <TableHead>Stream Title</TableHead>
                 <TableHead>Stream Status</TableHead>
-                <TableHead>Picking Status</TableHead>
+                <TableHead>Picks Status</TableHead>
                 <TableHead>Users</TableHead>
                 <TableHead>Actions</TableHead>
               </TableRow>

--- a/src/components/admin/StreamTableList.tsx
+++ b/src/components/admin/StreamTableList.tsx
@@ -19,7 +19,7 @@ import {
            <TableRow>
              <TableHead>Stream Title</TableHead>
              <TableHead>Stream Status</TableHead>
-             <TableHead>Picking Status</TableHead>
+             <TableHead>Picks Status</TableHead>
              <TableHead>Users</TableHead>
              <TableHead>Actions</TableHead>
            </TableRow>

--- a/src/components/admin/UserTable.tsx
+++ b/src/components/admin/UserTable.tsx
@@ -223,7 +223,7 @@ export const UserTable: React.FC<Props> = ({ searchUserQuery }) => {
               <TableRow>
                 <TableHead>User</TableHead>
                 <TableHead>Gold Balance</TableHead>
-                <TableHead>Sweep Coins</TableHead>
+                <TableHead>Stream Coins</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead>Created</TableHead>
                 <TableHead>Email</TableHead>

--- a/src/components/deposit/BuyCoins.tsx
+++ b/src/components/deposit/BuyCoins.tsx
@@ -121,7 +121,7 @@ const BuyCoins = ({
                     </div>
                     <div className="flex flex-col gap-1">
                       <span className="text-xs font-bold text-[#0D0D0D] uppercase bg-[#BDFF00] text-center w-14 rounded-sm">Promo</span>
-                      <span className="text-xs text-[#BDFF00]">Get {Number(option.sweepCoinCount || 0)?.toLocaleString('en-US')} free sweep coins</span>
+                      <span className="text-xs text-[#BDFF00]">Get {Number(option.sweepCoinCount || 0)?.toLocaleString('en-US')} free Stream Coins</span>
                     </div>
                   </div>
 

--- a/src/components/navigation/UserDropdown.tsx
+++ b/src/components/navigation/UserDropdown.tsx
@@ -91,7 +91,7 @@ export const UserDropdown = ({ profile, onLogout }: UserDropdownProps) => {
         </DropdownMenuItem>
 
         <DropdownMenuItem asChild className="cursor-pointer">
-          <Link to="/withdraw">Redeem Sweep Coins</Link>
+          <Link to="/withdraw">Redeem Stream Coins</Link>
         </DropdownMenuItem>
 
         <DropdownMenuItem asChild className="cursor-pointer">

--- a/src/components/navigation/WalletDropdown.tsx
+++ b/src/components/navigation/WalletDropdown.tsx
@@ -47,16 +47,16 @@ export const WalletDropdown = ({ walletBalance }: WalletDropdownProps) => {
                     <Button variant="ghost" className="gap-2 group items-center">
                       <img
                         src="/icons/sweep-coins.png"
-                        alt="sweep-coins"
+                        alt="Stream Coins"
                         className="h-4 w-6"
                       />
                       {/* <BanknoteArrowUp className="h-4 w-4 text-[#BDFF00] group-hover:text-black transition-colors" /> */}
-                      <Link to="/deposit" className="text-sm text-green-500 group-hover:text-black transition-colors text-nowrap hover:text-green-400">{Number(walletBalance)?.toLocaleString('en-US')} Sweep Coins</Link>
+                      <Link to="/deposit" className="text-sm text-green-500 group-hover:text-black transition-colors text-nowrap hover:text-green-400">{Number(walletBalance)?.toLocaleString('en-US')} Stream Coins</Link>
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent hidden side="bottom" className="max-w-[250px]">
                     <p>
-                      Sweep Coins will be used for cash picking and is not a part of the private
+                      Stream Coins will be used for cash picking and is not a part of the private
                       beta yet.
                     </p>
                   </TooltipContent>

--- a/src/components/navigation/WalletDropdown.tsx
+++ b/src/components/navigation/WalletDropdown.tsx
@@ -56,7 +56,7 @@ export const WalletDropdown = ({ walletBalance }: WalletDropdownProps) => {
                   </TooltipTrigger>
                   <TooltipContent hidden side="bottom" className="max-w-[250px]">
                     <p>
-                      Stream Coins will be used for cash picking and is not a part of the private
+                      Stream Coins will be used for cash picks and is not a part of the private
                       beta yet.
                     </p>
                   </TooltipContent>

--- a/src/components/stream/BetTokens.tsx
+++ b/src/components/stream/BetTokens.tsx
@@ -157,7 +157,7 @@ export default function BetTokens({
     if (lockedOptions) {
       toast({
         variant: 'destructive',
-        description: 'Admin has locked the picking round',
+        description: 'Admin has locked the picks round',
       });
       return;
     }
@@ -239,7 +239,7 @@ export default function BetTokens({
             if (lockedOptions) {
               toast({
                 variant: 'destructive',
-                description: 'Admin has locked the picking round',
+                description: 'Admin has locked the picks round',
               });
             }
           }}
@@ -405,7 +405,7 @@ export default function BetTokens({
         <div>
         
           <p className="text-2xl font-bold text-[#FFFFFF] text-center pt-20 pb-4">
-             Picking is locked for this round
+             Picks are locked for this round
           </p>
         </div>
 

--- a/src/components/stream/BetTokens.tsx
+++ b/src/components/stream/BetTokens.tsx
@@ -198,10 +198,10 @@ export default function BetTokens({
       
       <div className="flex flex-col xs:flex-col sm:flex-row items-start sm:items-center justify-between w-full text-xl font-medium sm:text-xl text-sm gap-2">
         <div className="text-[rgba(255,255,255,1)] text-2xl font-bold sm:text-xl text-base">
-          Pick <span style={{ color: 'rgba(189,255,0,1)' }} className="text-2xl font-bold sm:text-xl text-base">{betAmount?.toLocaleString('en-US')}</span> {isSweepCoins ? ' Sweep Coins' : ' Gold Coins'}
+          Pick <span style={{ color: 'rgba(189,255,0,1)' }} className="text-2xl font-bold sm:text-xl text-base">{betAmount?.toLocaleString('en-US')}</span> {isSweepCoins ? ' Stream Coins' : ' Gold Coins'}
           <span className="ml-3 bg-[#242424] rounded-[28px] px-4 py-2 text-[rgba(255, 255, 255, 1)] text-xs font-normal sm:text-xs text-[10px] max-w-[160px] truncate" title={bettingData?.bettingRounds?.[0]?.roundName}>
           {isSweepCoins
-            ? `Available Sweep Coins: ${Number(session?.walletBalanceSweepCoin || 0).toLocaleString('en-US')}`
+            ? `Available Stream Coins: ${Number(session?.walletBalanceSweepCoin || 0).toLocaleString('en-US')}`
             : `Available Gold Coins: ${Number(session?.walletBalanceGoldCoin || 0).toLocaleString('en-US')}`
           }
             </span>
@@ -209,7 +209,7 @@ export default function BetTokens({
         
         <div className="flex flex-col xs:flex-col sm:flex-row gap-2 sm:w-auto">
           <span className="bg-[#242424] rounded-[28px] px-4 py-2 text-[rgba(255, 255, 255, 1)] text-xs font-normal sm:text-xs text-[10px]">
-            Total Pot: {`${totalPot} ${isSweepCoins ? ' Sweep Coins' : ' Gold Coins'}`}
+            Total Pot: {`${totalPot} ${isSweepCoins ? ' Stream Coins' : ' Gold Coins'}`}
             </span>
         </div>
        

--- a/src/components/stream/LockTokens.tsx
+++ b/src/components/stream/LockTokens.tsx
@@ -95,7 +95,7 @@ export default function LockTokens({
           <div className="bg-[#242424] flex flex-col sm:flex-row sm:justify-between items-center rounded-t-2xl p-3 sm:p-5 px-[20px] sm:px-[55px] pr-[20px] sm:pr-[55px] gap-3 sm:gap-4 text-center">
             <div className="flex-shrink-0 w-full sm:w-auto">
               <p className="text-xs text-[#606060] font-semibold text-center pb-1">Your pick</p>
-              <p className="font-medium text-sm sm:text-[16px] text-[#D7DFEF]">{Number(localBetAmount)?.toLocaleString('en-US')} {updatedCurrency === CurrencyType.GOLD_COINS ? 'Gold Coins' : 'Sweep Coins'}</p>
+              <p className="font-medium text-sm sm:text-[16px] text-[#D7DFEF]">{Number(localBetAmount)?.toLocaleString('en-US')} {updatedCurrency === CurrencyType.GOLD_COINS ? 'Gold Coins' : 'Stream Coins'}</p>
             </div>
             <div className="flex-1 sm:min-w-0 w-full border-t sm:border-t-0 sm:border-1 border-[#2C2C2C] pt-3 sm:pt-0 sm:pl-4">
               <p className="text-xs text-[#606060] font-semibold text-center pb-1">Selected winner</p>

--- a/src/components/stream/StreamContent.tsx
+++ b/src/components/stream/StreamContent.tsx
@@ -249,7 +249,7 @@ export const StreamContent = ({
     socketInstance.on('betOpened', (update) => {
       console.log('betOpened', update);
       toast({
-        description:"New picking options available!",
+        description:"New picks options available!",
         variant: 'default',
       });
       resetBetData();
@@ -258,7 +258,7 @@ export const StreamContent = ({
     socketInstance.on('betCancelledByAdmin', (update) => {
       queryClient.prefetchQuery({ queryKey: ['session'] });
       toast({
-        description:"Current picking round cancelled by admin.",
+        description:"Current picks round cancelled by admin.",
         variant: 'destructive',
         duration: 4000,
       });
@@ -747,7 +747,7 @@ export const StreamContent = ({
                   className="w-[100%] h-[100%] object-contain"
                 />
               </div>
-              <p className="text-2xl text-[rgba(255, 255, 255, 1)] text-center pt-4 pb-4" style={FabioBoldStyle}>No picking options available</p>
+              <p className="text-2xl text-[rgba(255, 255, 255, 1)] text-center pt-4 pb-4" style={FabioBoldStyle}>No picks options available</p>
             </div> : <div className="flex gap-4 p-6 rounded-[16px] shadow-lg overflow-x-auto overflow-y-hidden flex-nowrap" style={{ backgroundColor:'rgba(24, 24, 24, 1)' }} ref={horizontalScrollRef}>
 
             {roundDetails?.map(

--- a/src/components/stream/StreamContent.tsx
+++ b/src/components/stream/StreamContent.tsx
@@ -764,7 +764,7 @@ export const StreamContent = ({
                     <div className="flex flex-col items-center gap-2 mt-2">
                       <p className="text-white font-bold">{round?.winningOption?.[0]?.variableName} as winner</p>
                       <span className="text-white text-sm font-medium">won {round?.winningOption?.[0]?.totalGoldCoinAmt} gold coins</span>
-                      <span className="text-white text-sm font-medium">and {round?.winningOption?.[0]?.totalSweepCoinAmt} sweep coins</span>
+                      <span className="text-white text-sm font-medium">and {round?.winningOption?.[0]?.totalSweepCoinAmt} Stream Coins</span>
                     </div>
                   </div>
                 )} else if (isRoundCancelled) {

--- a/src/components/stream/UpcomingStreams.tsx
+++ b/src/components/stream/UpcomingStreams.tsx
@@ -26,7 +26,7 @@ const DesktopStreamItem = ({ stream }: { stream: any }) => {
   const totalPotAmount = Number(isSweepCoins 
     ? stream.totalBetsSweepCoinAmount || 0 
     : stream.totalBetsGoldCoinAmount || 0);
-  const currencyLabel = isSweepCoins ? 'sweep coins' : 'gold coins';
+  const currencyLabel = isSweepCoins ? 'Stream Coins' : 'gold coins';
   
   // Format number with comma separators for en-US locale
   const formattedAmount = totalPotAmount.toLocaleString('en-US');
@@ -115,7 +115,7 @@ const MobileStreamItem = ({ stream }: { stream: any }) => {
   const totalPotAmount = Number(isSweepCoins 
     ? stream.totalBetsSweepCoinAmount || 0 
     : stream.totalBetsGoldCoinAmount || 0);
-  const currencyLabel = isSweepCoins ? 'sweep(s)' : 'gold(s)';
+  const currencyLabel = isSweepCoins ? 'Stream Coin(s)' : 'gold(s)';
   
   // Format number with comma separators for en-US locale
   const formattedAmount = totalPotAmount.toLocaleString('en-US');

--- a/src/components/withdraw/Kyc.tsx
+++ b/src/components/withdraw/Kyc.tsx
@@ -146,7 +146,7 @@ export default function Kyc() {
                 <CardHeader>
                   <CardTitle>Redeem Verification</CardTitle>
                   <CardDescription>
-                      Before you can redeem sweep coins, we need to verify your identification.
+                      Before you can redeem Stream Coins, we need to verify your identification.
                   </CardDescription>
                 </CardHeader>
                 <CardContent>

--- a/src/components/withdraw/Redeem.tsx
+++ b/src/components/withdraw/Redeem.tsx
@@ -48,7 +48,7 @@ export default function Redeem() {
       return;
     } else if (num > sweepBalance) {
       setUsdValue(null);
-      setError(`You only have ${sweepBalance} sweep coins`);
+      setError(`You only have ${sweepBalance} Stream Coins`);
       return;
     }
     setLoading(true);
@@ -249,12 +249,12 @@ export default function Redeem() {
             </CardHeader> :
             <>
               <CardHeader>
-                <CardTitle>Redeem Sweep Coins</CardTitle>
+                <CardTitle>Redeem Stream Coins</CardTitle>
                 <CardDescription>
-                  Enter the amount of sweep coins to redeem.
+                  Enter the amount of Stream Coins to redeem.
                   <div className='mt-4'>
-                    Your sweep coin balance: {sweepBalance?.toLocaleString('en-US')}<br />
-                    {session?.sweepCoinsPerDollar} sweep coins = $1
+                    Your Stream Coin balance: {sweepBalance?.toLocaleString('en-US')}<br />
+                    {session?.sweepCoinsPerDollar} Stream Coins = $1
                     <div className="flex justify-between">
                       <span>Min: {Number(session?.minWithdrawableSweepCoins || 0)?.toLocaleString('en-US')} coins</span>
                       <span>Max: {Number((session?.maxWithdrawableSweepCoins ?? session?.walletBalanceSweepCoin) || 0)?.toLocaleString('en-US')}  coins</span>
@@ -265,7 +265,7 @@ export default function Redeem() {
               <CardContent>
                 <form className="space-y-4">
                   <div>
-                    <Label htmlFor="sweepCoins">Sweep Coins</Label>
+                    <Label htmlFor="sweepCoins">Stream Coins</Label>
                     <Input
                       id="sweepCoins"
                       type="number"

--- a/src/components/withdraw/Withdraw.tsx
+++ b/src/components/withdraw/Withdraw.tsx
@@ -58,7 +58,7 @@ export default function Withdraw({
 
 		  toast({ 
 			title: 'Withdraw initiated', 
-			description: `Your request to redeem ${(sweepCoins || 0)?.toLocaleString('en-US')} sweep coins has initiated`,
+			description: `Your request to redeem ${(sweepCoins || 0)?.toLocaleString('en-US')} Stream Coins has initiated`,
 			duration: 8000,
 		});
 		  navigate('/');
@@ -262,7 +262,7 @@ export default function Withdraw({
 				
 				<div className="text-center mb-8">
 					<h1 className="text-4xl font-black mb-3 bg-gradient-to-r from-[#BDFF00] via-[#9DFF33] to-[#7DFF66] bg-clip-text text-transparent">
-						Redeem Sweep Coins
+						Redeem Stream Coins
 					</h1>
 					<p className="text-gray-400 text-lg">Complete your redeem request</p>
 				</div>

--- a/src/contexts/BettingStatusContext.tsx
+++ b/src/contexts/BettingStatusContext.tsx
@@ -68,7 +68,7 @@ export const BettingStatusProvider = ({ children }: { children: ReactNode }) => 
               </span>
               {" "} 
               <span className='text-green-500'>
-                Sweep Coins
+                Stream Coins
               </span> 
               !
             </div>,
@@ -92,7 +92,7 @@ export const BettingStatusProvider = ({ children }: { children: ReactNode }) => 
               </span>
               {" "} 
               <span className='text-green-500'>
-                Sweep Coins
+                Stream Coins
               </span> 
               {" "}
               was successful!
@@ -117,10 +117,10 @@ export const BettingStatusProvider = ({ children }: { children: ReactNode }) => 
               </span>
               {" "} 
               <span className='text-green-500'>
-                Sweep Coins 
+                Stream Coins 
               </span> 
               {" "}
-              failed. Your sweep coins has been refunded.
+              failed. Your Stream Coins has been refunded.
             </div>,
           variant: 'default',
           duration: 7000,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -288,7 +288,7 @@ useEffect(() => {
         <div className="max-w-3xl mx-auto text-center space-y-4">
           <h1 className="text-4xl md:text-5xl font-bold">
             Predict the Internet's <br />
-            <span className="text-[#BDFF00]">best</span> moments
+            <span className="text-[#BDFF00]">randomest</span> moments
           </h1>
           <p className='text-[#FFFFFFBF]'>
             Live picks for games created on the Internet.


### PR DESCRIPTION
This pull request updates the terminology across the codebase, replacing "Sweep Coins" with "Stream Coins" to ensure consistency in user-facing text and internal references. The changes affect UI labels, tooltips, error messages, and component props throughout the application, including wallet history, betting, admin, and withdrawal flows.

**Terminology updates (Sweep Coins → Stream Coins):**

* Renamed all instances of "Sweep Coins" to "Stream Coins" in wallet history displays, coin type labels, and transaction amounts in `WalletHistory.tsx`. [[1]](diffhunk://#diff-f258f59a1a1d911d8f337ed1851c780373e22d881abd78f5c701932ff4dd464aL115-R115) [[2]](diffhunk://#diff-f258f59a1a1d911d8f337ed1851c780373e22d881abd78f5c701932ff4dd464aL148-R148) [[3]](diffhunk://#diff-f258f59a1a1d911d8f337ed1851c780373e22d881abd78f5c701932ff4dd464aL200-R200) [[4]](diffhunk://#diff-f258f59a1a1d911d8f337ed1851c780373e22d881abd78f5c701932ff4dd464aL237-R237)
* Updated coin references in betting, stream, and admin components, including pot totals, pick amounts, round winnings, and user tables (`BetTokens.tsx`, `LockTokens.tsx`, `StreamContent.tsx`, `UpcomingStreams.tsx`, `AdminBettingRoundsCard.tsx`, `UserTable.tsx`). [[1]](diffhunk://#diff-c62a5a4284a5ac7e50c61627131b30f6554b40baf0dbce7a2d414d56cd77e0aaL201-R212) [[2]](diffhunk://#diff-55b1ed1accb8c7129386f64c05756b03fe1467fc607b28863b9cdbfd32be7d28L98-R98) [[3]](diffhunk://#diff-e5c9697715dc1ca7de61e2734c65133627b882d36856d6fb7fe1e481911e8ba0L767-R767) [[4]](diffhunk://#diff-c0bbfbeefc7308a46da94b61a90b216c246275c6ab9139cdfc6a7c48030db82eL29-R29) [[5]](diffhunk://#diff-c0bbfbeefc7308a46da94b61a90b216c246275c6ab9139cdfc6a7c48030db82eL118-R118) [[6]](diffhunk://#diff-4460db11568b03c5de9327d1a565b9a50bf64a4495b0aa49378b67e2b4e93ca5L400-R400) [[7]](diffhunk://#diff-4460db11568b03c5de9327d1a565b9a50bf64a4495b0aa49378b67e2b4e93ca5L574-R576) [[8]](diffhunk://#diff-4659b266240d09033bccef9e3d7c354fad07279f7d8d33fe20ebd02bfb151a8eL226-R226)

**Withdrawal and redemption flow updates:**

* Changed all withdrawal-related UI text and error messages to use "Stream Coins" instead of "Sweep Coins" in `Withdraw.tsx`, `Redeem.tsx`, and `Kyc.tsx`. [[1]](diffhunk://#diff-d14a1c891585b934382d92bde85a9c271cb1bfc1e2c69c4f46ced3547a974983L61-R61) [[2]](diffhunk://#diff-d14a1c891585b934382d92bde85a9c271cb1bfc1e2c69c4f46ced3547a974983L265-R265) [[3]](diffhunk://#diff-77b1e3cbf0425ebab3f1d78fd26c8ec1b69588e772234613055b85802103c5f7L51-R51) [[4]](diffhunk://#diff-77b1e3cbf0425ebab3f1d78fd26c8ec1b69588e772234613055b85802103c5f7L252-R257) [[5]](diffhunk://#diff-77b1e3cbf0425ebab3f1d78fd26c8ec1b69588e772234613055b85802103c5f7L268-R268) [[6]](diffhunk://#diff-cb0b9dfe3c0e6afedb673b826ca7ac9eb4e1590bd92209e8197dcc8397a373abL149-R149)

**Navigation and dropdowns:**

* Updated navigation dropdowns and tooltips to reference "Stream Coins" for deposits and redemptions in `UserDropdown.tsx` and `WalletDropdown.tsx`. [[1]](diffhunk://#diff-1b29ad2edddb29892180958e09a54d48d8dc705b8f6f88a1bb584eead2d46c8dL94-R94) [[2]](diffhunk://#diff-e5a01bb6c735e645c84b76dd5017711db377ff11a980a0277c29e011b56c58f8L50-R59)

**Betting status and stream card components:**

* Changed status indicators and labels to use "Picks Open"/"Picks Locked" and "Stream Coins" in `StreamCard.tsx` and `BettingStatusContext.tsx`. [[1]](diffhunk://#diff-f8a603a8fc4fc3003099870a4274d0af01d3d5ae94a19a373c5666226d596f63L221-R221) [[2]](diffhunk://#diff-8acf5ba41d16c549d66e0b94c753cd54e983c940f7e1188260cef40955108913L71-R71)

**Deposit and promo labels:**

* Updated promotional text to offer free "Stream Coins" instead of "Sweep Coins" in `BuyCoins.tsx`.