### PR TITLE
Fix/zero balance redirect

### DIFF
--- a/src/components/stream/BetTokens.tsx
+++ b/src/components/stream/BetTokens.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { useNavigate } from 'react-router-dom';
 import { useToast } from '@/components/ui/use-toast';
 import { BettingRoundStatus, CurrencyType } from '@/enums';
 import { useCurrencyContext } from "@/contexts/CurrencyContext";
@@ -83,6 +84,7 @@ export default function BetTokens({
   const { toast } = useToast();
   const { currency } = useCurrencyContext();
   const isMobile = useIsMobile();
+  const navigate = useNavigate();
 
   const [betAmount, setBetAmount] = useState(selectedAmount || 0);
   const [selectedColor, setSelectedColor] = useState("");
@@ -172,10 +174,28 @@ export default function BetTokens({
     }
   };
 
+  // Check if wallet balance is 0
+  const walletBalance = Number(isSweepCoins ? session?.walletBalanceSweepCoin : session?.walletBalanceGoldCoin) || 0;
+  const hasZeroBalance = session != null && walletBalance === 0 && !isEditing;
+
 
   return (
     <div>
-      {(bettingData?.bettingRounds?.[0]?.status === BettingRoundStatus.OPEN && !lockedBet)  ? (
+      {/* Zero Balance Message */}
+      {hasZeroBalance ? (
+        <div className="bg-[#181818] p-4 rounded-[16px] flex flex-col items-center space-y-3 w-full mx-auto">
+          <h2 className="text-white text-lg font-semibold">Your wallet balance is 0</h2>
+          <p className="text-gray-400 text-sm text-center">
+            You need {isSweepCoins ? 'Sweep Coins' : 'Gold Coins'} to place a pick
+          </p>
+          <button
+            className="w-full bg-lime-400 text-black font-medium py-2 rounded-full hover:bg-lime-300 transition"
+            onClick={() => navigate('/deposit')}
+          >
+            Buy More Coins
+          </button>
+        </div>
+      ) : (bettingData?.bettingRounds?.[0]?.status === BettingRoundStatus.OPEN && !lockedBet) ? (
     <div
       className="rounded-2xl p-4 w-full text-white space-y-4 shadow-lg border text-base sm:text-base text-xs"
       style={{

--- a/src/components/stream/BetTokens.tsx
+++ b/src/components/stream/BetTokens.tsx
@@ -178,7 +178,16 @@ export default function BetTokens({
     Number(isSweepCoins ? bettingData?.walletSweepCoin : bettingData?.walletGoldCoin) || 0,
     [isSweepCoins, bettingData?.walletSweepCoin, bettingData?.walletGoldCoin]
   );
-  const hasZeroBalance = session != null && walletBalance === 0 && !isEditing;
+  
+  // Check if betting is currently available (round is open and not locked)
+  const isBettingAvailable = bettingData?.bettingRounds?.[0]?.status === BettingRoundStatus.OPEN && !lockedBet;
+  
+  // Only show zero balance message when betting would be available if user had funds
+  const hasZeroBalance = session != null && 
+                         bettingData != null && 
+                         isBettingAvailable &&
+                         walletBalance === 0 && 
+                         !isEditing;
 
 
   return (
@@ -192,12 +201,12 @@ export default function BetTokens({
           </p>
           <button
             className="w-full bg-lime-400 text-black font-medium py-2 rounded-full hover:bg-lime-300 transition"
-            onClick={() => navigate(`/deposit?redirect=/stream/${streamId}`)}
+            onClick={() => navigate('/deposit')}
           >
             Buy More Coins
           </button>
         </div>
-      ) : (bettingData?.bettingRounds?.[0]?.status === BettingRoundStatus.OPEN && !lockedBet) ? (
+      ) : isBettingAvailable ? (
     <div
       className="rounded-2xl p-4 w-full text-white space-y-4 shadow-lg border text-base sm:text-base text-xs"
       style={{

--- a/src/components/stream/BetTokens.tsx
+++ b/src/components/stream/BetTokens.tsx
@@ -173,16 +173,16 @@ export default function BetTokens({
     }
   };
 
-  // Check if wallet balance is 0 - using bettingData as source of truth (consistent with slider logic)
+  // Check if wallet balance is 0. bettingData is source of truth with slider logic
   const walletBalance = useMemo(() => 
     Number(isSweepCoins ? bettingData?.walletSweepCoin : bettingData?.walletGoldCoin) || 0,
     [isSweepCoins, bettingData?.walletSweepCoin, bettingData?.walletGoldCoin]
   );
   
-  // Check if betting is currently available (round is open and not locked)
+  // Check if betting is available. Round is open, not locked
   const isBettingAvailable = bettingData?.bettingRounds?.[0]?.status === BettingRoundStatus.OPEN && !lockedBet;
   
-  // Only show zero balance message when betting would be available if user had funds
+  // Only render zero balance message when betting is available if user had funds and isn't editing
   const hasZeroBalance = session != null && 
                          bettingData != null && 
                          isBettingAvailable &&

--- a/src/components/stream/BetTokens.tsx
+++ b/src/components/stream/BetTokens.tsx
@@ -129,7 +129,6 @@ export default function BetTokens({
   const isBetButtonEnabled = selectedColor !== "";
 
    useEffect(() => {
-      const isSweepCoins = currency === CurrencyType.SWEEP_COINS;
       const maxBetLimit = isSweepCoins ? BETTING_LIMITS.MAX_SWEEP_COINS_BET : BETTING_LIMITS.MAX_GOLD_COINS_BET;
       
       const currentBetAmount = isEditing ? Number(isSweepCoins 
@@ -174,10 +173,10 @@ export default function BetTokens({
     }
   };
 
-  // Check if wallet balance is 0
+  // Check if wallet balance is 0 - using bettingData as source of truth (consistent with slider logic)
   const walletBalance = useMemo(() => 
-    Number(isSweepCoins ? session?.walletBalanceSweepCoin : session?.walletBalanceGoldCoin) || 0,
-    [isSweepCoins, session?.walletBalanceSweepCoin, session?.walletBalanceGoldCoin]
+    Number(isSweepCoins ? bettingData?.walletSweepCoin : bettingData?.walletGoldCoin) || 0,
+    [isSweepCoins, bettingData?.walletSweepCoin, bettingData?.walletGoldCoin]
   );
   const hasZeroBalance = session != null && walletBalance === 0 && !isEditing;
 
@@ -193,7 +192,7 @@ export default function BetTokens({
           </p>
           <button
             className="w-full bg-lime-400 text-black font-medium py-2 rounded-full hover:bg-lime-300 transition"
-            onClick={() => navigate('/deposit')}
+            onClick={() => navigate(`/deposit?redirect=/stream/${streamId}`)}
           >
             Buy More Coins
           </button>

--- a/src/components/stream/BetTokens.tsx
+++ b/src/components/stream/BetTokens.tsx
@@ -203,7 +203,7 @@ export default function BetTokens({
             className="w-full bg-lime-400 text-black font-medium py-2 rounded-full hover:bg-lime-300 transition"
             onClick={() => navigate('/deposit')}
           >
-            Buy More Coins
+            Buy Coins
           </button>
         </div>
       ) : isBettingAvailable ? (

--- a/src/components/stream/BetTokens.tsx
+++ b/src/components/stream/BetTokens.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useNavigate } from 'react-router-dom';
 import { useToast } from '@/components/ui/use-toast';
 import { BettingRoundStatus, CurrencyType } from '@/enums';
@@ -175,7 +175,10 @@ export default function BetTokens({
   };
 
   // Check if wallet balance is 0
-  const walletBalance = Number(isSweepCoins ? session?.walletBalanceSweepCoin : session?.walletBalanceGoldCoin) || 0;
+  const walletBalance = useMemo(() => 
+    Number(isSweepCoins ? session?.walletBalanceSweepCoin : session?.walletBalanceGoldCoin) || 0,
+    [isSweepCoins, session?.walletBalanceSweepCoin, session?.walletBalanceGoldCoin]
+  );
   const hasZeroBalance = session != null && walletBalance === 0 && !isEditing;
 
 


### PR DESCRIPTION
This pull request enhances the user experience in the `BetTokens` component by introducing a new zero-balance message and improving code clarity around betting availability and wallet balance checks. The most important changes are grouped below.

**User Experience Improvements:**

* Added a zero balance message that is shown when the user's wallet balance is zero and betting is available, including a "Buy Coins" button that navigates to the deposit page.
* The zero balance message is only displayed when the user is not editing a bet, has an active session, and betting is open.

**Code Quality and Logic Enhancements:**

* Introduced `useMemo` to efficiently calculate `walletBalance` based on the current currency and betting data.
* Added `isBettingAvailable` and `hasZeroBalance` variables to clarify rendering logic and improve maintainability.
* Cleaned up unused variable `isSweepCoins` in the `useEffect` hook, relying on the refactored logic for bet limits.

**Routing Integration:**

* Imported and used `useNavigate` from `react-router-dom` to handle navigation to the deposit page when the user has zero balance. [[1]](diffhunk://#diff-c62a5a4284a5ac7e50c61627131b30f6554b40baf0dbce7a2d414d56cd77e0aaL1-R2) [[2]](diffhunk://#diff-c62a5a4284a5ac7e50c61627131b30f6554b40baf0dbce7a2d414d56cd77e0aaR87)