### PR TITLE
hotFix: reorder streams to display MrBeast streams at the end

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -353,14 +353,31 @@ useEffect(() => {
             </Alert>
           ) : isStreams ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {streamsData && streamsData.data?.map(stream => (
-                <StreamCard
-                  key={stream.id}
-                  stream={stream}
-                  isAdmin={session?.role === 'admin'}
-                  showAdminControls={false}
-                />
-              ))}
+              {streamsData && (() => {
+                // Separate MrBeast streams from others
+                const mrBeastStreams: any[] = [];
+                const otherStreams: any[] = [];
+                
+                streamsData.data?.forEach((stream: any) => {
+                  if (stream.streamName?.toLowerCase().includes('mrbeast')) {
+                    mrBeastStreams.push(stream);
+                  } else {
+                    otherStreams.push(stream);
+                  }
+                });
+                
+                // Combine arrays with MrBeast streams at the end
+                const reorderedStreams = [...otherStreams, ...mrBeastStreams];
+                
+                return reorderedStreams.map(stream => (
+                  <StreamCard
+                    key={stream.id}
+                    stream={stream}
+                    isAdmin={session?.role === 'admin'}
+                    showAdminControls={false}
+                  />
+                ));
+              })()}
             </div>
           ) : activeTab === 'upcoming' ? (
             <div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -353,31 +353,14 @@ useEffect(() => {
             </Alert>
           ) : isStreams ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {streamsData && (() => {
-                // Separate MrBeast streams from others
-                const mrBeastStreams: any[] = [];
-                const otherStreams: any[] = [];
-                
-                streamsData.data?.forEach((stream: any) => {
-                  if (stream.streamName?.toLowerCase().includes('mrbeast')) {
-                    mrBeastStreams.push(stream);
-                  } else {
-                    otherStreams.push(stream);
-                  }
-                });
-                
-                // Combine arrays with MrBeast streams at the end
-                const reorderedStreams = [...otherStreams, ...mrBeastStreams];
-                
-                return reorderedStreams.map(stream => (
-                  <StreamCard
-                    key={stream.id}
-                    stream={stream}
-                    isAdmin={session?.role === 'admin'}
-                    showAdminControls={false}
-                  />
-                ));
-              })()}
+              {streamsData && streamsData.data?.sort((a, b) => (a.streamName?.toLowerCase().includes('mrbeast') ? 1 : 0) - (b.streamName?.toLowerCase().includes('mrbeast') ? 1 : 0)).map(stream => (
+                <StreamCard
+                  key={stream.id}
+                  stream={stream}
+                  isAdmin={session?.role === 'admin'}
+                  showAdminControls={false}
+                />
+              ))}
             </div>
           ) : activeTab === 'upcoming' ? (
             <div>


### PR DESCRIPTION
This pull request updates the stream listing logic on the main page to improve how streams are displayed. The most important change is that streams with "MrBeast" in their name are now shown at the end of the list, rather than mixed in with other streams.

**Stream ordering improvements:**

* Streams with "MrBeast" in their `streamName` are separated from other streams and displayed at the end of the stream grid, ensuring other streams appear first.