### PR TITLE
Hot fix/move mr beast to end

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -353,14 +353,31 @@ useEffect(() => {
             </Alert>
           ) : isStreams ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {streamsData && streamsData.data?.map(stream => (
-                <StreamCard
-                  key={stream.id}
-                  stream={stream}
-                  isAdmin={session?.role === 'admin'}
-                  showAdminControls={false}
-                />
-              ))}
+              {streamsData && (() => {
+                // Separate MrBeast streams from others
+                const mrBeastStreams: any[] = [];
+                const otherStreams: any[] = [];
+                
+                streamsData.data?.forEach((stream: any) => {
+                  if (stream.streamName?.toLowerCase().includes('mrbeast')) {
+                    mrBeastStreams.push(stream);
+                  } else {
+                    otherStreams.push(stream);
+                  }
+                });
+                
+                // Combine arrays with MrBeast streams at the end
+                const reorderedStreams = [...otherStreams, ...mrBeastStreams];
+                
+                return reorderedStreams.map(stream => (
+                  <StreamCard
+                    key={stream.id}
+                    stream={stream}
+                    isAdmin={session?.role === 'admin'}
+                    showAdminControls={false}
+                  />
+                ));
+              })()}
             </div>
           ) : activeTab === 'upcoming' ? (
             <div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -353,31 +353,14 @@ useEffect(() => {
             </Alert>
           ) : isStreams ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {streamsData && (() => {
-                // Separate MrBeast streams from others
-                const mrBeastStreams: any[] = [];
-                const otherStreams: any[] = [];
-                
-                streamsData.data?.forEach((stream: any) => {
-                  if (stream.streamName?.toLowerCase().includes('mrbeast')) {
-                    mrBeastStreams.push(stream);
-                  } else {
-                    otherStreams.push(stream);
-                  }
-                });
-                
-                // Combine arrays with MrBeast streams at the end
-                const reorderedStreams = [...otherStreams, ...mrBeastStreams];
-                
-                return reorderedStreams.map(stream => (
-                  <StreamCard
-                    key={stream.id}
-                    stream={stream}
-                    isAdmin={session?.role === 'admin'}
-                    showAdminControls={false}
-                  />
-                ));
-              })()}
+              {streamsData && streamsData.data?.sort((a, b) => (a.streamName?.toLowerCase().includes('mrbeast') ? 1 : 0) - (b.streamName?.toLowerCase().includes('mrbeast') ? 1 : 0)).map(stream => (
+                <StreamCard
+                  key={stream.id}
+                  stream={stream}
+                  isAdmin={session?.role === 'admin'}
+                  showAdminControls={false}
+                />
+              ))}
             </div>
           ) : activeTab === 'upcoming' ? (
             <div>


### PR DESCRIPTION
O(NlogN) beats O(N), GTK

This pull request makes a small change to the sorting logic for displaying streams on the index page. The update ensures that streams with "mrbeast" in their name are sorted in a specific way, likely to prioritize or deprioritize them in the list.

* Updated the `streamsData` sorting logic in `src/pages/Index.tsx` to sort streams based on whether their `streamName` includes "mrbeast" (case-insensitive).