### PR TITLE
Fix/picks locked conditional for quick pick button

### DIFF
--- a/src/components/StreamCard.tsx
+++ b/src/components/StreamCard.tsx
@@ -247,7 +247,11 @@ export const StreamCard = ({
                     : 'bg-emerald-500/50 text-white/80 border-emerald-500/50 cursor-not-allowed'
                 )}
               >
-                {isBettingOpen ? 'Quick Pick' : 'Picks Open Soon'}
+                {isBettingOpen 
+                  ? 'Quick Pick' 
+                  : isBettingLocked 
+                    ? 'Picks Locked' 
+                    : 'Picks Open Soon'}
               </Button>
             </div>
           </div>

--- a/src/components/StreamCard.tsx
+++ b/src/components/StreamCard.tsx
@@ -241,7 +241,7 @@ export const StreamCard = ({
                 }}
                 disabled={!isBettingOpen}
                 className={cn(
-                  'w-full rounded-full border font-medium text-[12px]',
+                  'w-full rounded-full border font-medium text-[12px] flex items-center justify-center gap-1.5',
                   isBettingOpen
                     ? 'bg-emerald-500 hover:bg-emerald-600 text-black border-emerald-500'
                     : 'bg-emerald-500/50 text-white/80 border-emerald-500/50 cursor-not-allowed'
@@ -250,7 +250,12 @@ export const StreamCard = ({
                 {isBettingOpen 
                   ? 'Quick Pick' 
                   : isBettingLocked 
-                    ? 'Picks Locked' 
+                    ? (
+                      <>
+                        <LockKeyhole className="h-3 w-3" />
+                        <span>Picks Locked</span>
+                      </>
+                    )
                     : 'Picks Open Soon'}
               </Button>
             </div>


### PR DESCRIPTION
This pull request introduces a small UI improvement to the `StreamCard` component, specifically enhancing the betting button to provide clearer feedback to users on its state.

* Betting button now displays a lock icon and "Picks Locked" text when picks are locked, improving clarity for users. (`src/components/StreamCard.tsx`)
* Button styling updated to use flex layout for better alignment of icon and text. (`src/components/StreamCard.tsx`)