### PR TITLE
fix: replace betting words with picks

### DIFF
--- a/src/components/admin/AdminManagement.tsx
+++ b/src/components/admin/AdminManagement.tsx
@@ -75,7 +75,7 @@ export const AdminManagement = ({
   const isSweepCoins = currency === CurrencyType.SWEEP_COINS;
 
   const tabs = [
-    { key: 'livestreams', label: 'Livestreams' },
+    { key: 'livestreams', label: 'Live Streams' },
     { key: 'ended-streams', label: 'Ended Streams' },
     { key: 'users', label: 'Users' },
   ];


### PR DESCRIPTION
This pull request introduces a minor UI update to the `AdminManagement` component. The label for the "Livestreams" tab has been changed to "Live Streams" for improved clarity.

* Renamed the tab label from "Livestreams" to "Live Streams" in the `AdminManagement.tsx` component.