### PR TITLE
Fix/admin dashboard ended streams pagination

### DIFF
--- a/src/hooks/useStreamManagement.tsx
+++ b/src/hooks/useStreamManagement.tsx
@@ -62,9 +62,7 @@ export const useStreamManagement = () => {
   }, [searchStreamQuery, refetchStreams]);
 
   useEffect(() => {
-    if (endedStreamsRangeRef.current !== '') {
-      refetchEndedStreams();
-    }
+    refetchEndedStreams();
   }, [refetchEndedStreams]);
 
   return {

--- a/src/hooks/useStreamManagement.tsx
+++ b/src/hooks/useStreamManagement.tsx
@@ -61,6 +61,12 @@ export const useStreamManagement = () => {
     }
   }, [searchStreamQuery, refetchStreams]);
 
+  useEffect(() => {
+    if (endedStreamsRangeRef.current !== '') {
+      refetchEndedStreams();
+    }
+  }, [refetchEndedStreams]);
+
   return {
     profile: session,
     isProfileLoading: isLoading,

--- a/src/hooks/useStreamManagement.tsx
+++ b/src/hooks/useStreamManagement.tsx
@@ -8,6 +8,7 @@ export const useStreamManagement = () => {
   const { toast } = useToast();
   const [searchStreamQuery, setSearchStreamQuery] = useState();
   const rangeRef = useRef('[0,7]');
+  const endedStreamsRangeRef = useRef('[0,7]');
   const { isLoading, isFetching, session } = useAuthContext();
 
   const { data: streams, refetch: refetchStreams } = useQuery({
@@ -30,8 +31,8 @@ export const useStreamManagement = () => {
     queryKey: ['ended-streams'],
     queryFn: async () => {
       const response = await adminAPI.getStreams({
-        range: searchStreamQuery ? '[0,24]' : rangeRef.current,
-        sort: '["createdAt","DESC"]',
+        range: endedStreamsRangeRef.current,
+        sort: '["endTime","DESC"]',
         filter: JSON.stringify({ streamStatus: 'ended' }),
       });
 
@@ -47,6 +48,11 @@ export const useStreamManagement = () => {
   const handleRefetchStreams = (range?: string) => {
     rangeRef.current = range || '';
     refetchStreams();
+  };
+
+  const handleRefetchEndedStreams = (range?: string) => {
+    endedStreamsRangeRef.current = range || '';
+    refetchEndedStreams();
   };
 
   useEffect(() => {
@@ -65,6 +71,6 @@ export const useStreamManagement = () => {
     deleteStream,
     handleRefetchStreams,
     endedStreams,
-    refetchEndedStreams,
+    handleRefetchEndedStreams,
   };
 };

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -16,7 +16,7 @@ const Admin = () => {
     handleRefetchStreams,
     setSearchStreamQuery,
     endedStreams,
-    refetchEndedStreams,
+    handleRefetchEndedStreams,
   } = useStreamManagement();
   const queryClient = useQueryClient();
   const [resetKey, setResetKey] = useState(0);
@@ -110,7 +110,7 @@ const Admin = () => {
         setSearchStreamQuery={setSearchStreamQuery}
         onStreamContentChange={setIsStreamContent}
         endedStreams={endedStreams}
-        refetchEndedStreams={refetchEndedStreams}
+        refetchEndedStreams={range => handleRefetchEndedStreams(range)}
       />
     </AdminLayout>
   );


### PR DESCRIPTION
This pull request refactors how ended streams are managed and refetched in the admin dashboard. The main improvement is the introduction of a dedicated range reference and handler for ended streams, allowing for more flexible and accurate querying and refreshing of ended stream data. The changes also update sorting to use the stream end time and ensure the new handler is used consistently across components.

**Ended Streams Management Improvements:**

* Added a separate `endedStreamsRangeRef` to independently track the range for ended streams, improving query flexibility.
* Updated the ended streams query to use `endedStreamsRangeRef` and to sort by `endTime` instead of `createdAt`, ensuring more relevant ordering of results.

**Refetching Logic Updates:**

* Introduced `handleRefetchEndedStreams`, a dedicated function to update the ended streams range and trigger a refetch, replacing the previous direct refetch method.
* Replaced usage of `refetchEndedStreams` with `handleRefetchEndedStreams` in both the hook's return value and its consumption in `Admin.tsx`, ensuring consistent usage of the new handler. [[1]](diffhunk://#diff-a9cc86e3a3138dce5c86275c7c49f0511e7b5824f5be52bd07f08d89065b3cbfL68-R78) [[2]](diffhunk://#diff-2480603155e8f1480c326e5325080141af09e89db6b57135173d81eea64161dcL19-R19) [[3]](diffhunk://#diff-2480603155e8f1480c326e5325080141af09e89db6b57135173d81eea64161dcL113-R113)