### PR TITLE
Bugfix/round 3 bug

### DIFF
--- a/src/components/stream/StreamContent.tsx
+++ b/src/components/stream/StreamContent.tsx
@@ -138,11 +138,13 @@ export const StreamContent = ({
   const setupSocketEventListeners = (socketInstance: any) => {
     if (!socketInstance) return;
 
+    /**
+     * Resets all betting-related UI state and syncs with server data.
+     * Called when a new round starts, a round is cancelled, or bet options open.
+     * This ensures the UI reflects a clean slate for the new betting round.
+     */
     const resetBetData = () => {
-      // Invalidate queries to get fresh data
-      queryClient.invalidateQueries({ queryKey: ['bettingData', streamId, session?.id] });
-      queryClient.invalidateQueries({ queryKey: ['selectedRoundData'] });
-      // Reset UI
+      // Clear all local betting state
       setTotalPotGoldCoins(undefined);
       setTotalPotSweepCoins(undefined);
       setPlaceBet(true);
@@ -156,9 +158,11 @@ export const StreamContent = ({
       setUpdatedCurrency(undefined);
       setIsEditing(false);
       setLoading(false);
-      // Get fresh data
-      refetchBettingData();
-      refetchRoundData();
+
+      // Invalidate cached queries to fetch fresh data from server
+      // This ensures we display the latest round and betting information
+      queryClient.invalidateQueries({ queryKey: ['bettingData', streamId, session?.id] });
+      queryClient.invalidateQueries({ queryKey: ['selectedRoundData'] });
     };
 
     socketInstance.on('scheduledStreamUpdatedToLive', () => {

--- a/src/components/stream/StreamContent.tsx
+++ b/src/components/stream/StreamContent.tsx
@@ -138,11 +138,6 @@ export const StreamContent = ({
   const setupSocketEventListeners = (socketInstance: any) => {
     if (!socketInstance) return;
 
-    /**
-     * Resets all betting-related UI state and syncs with server data.
-     * Called when a new round starts, a round is cancelled, or bet options open.
-     * This ensures the UI reflects a clean slate for the new betting round.
-     */
     const resetBetData = () => {
       // Clear all local betting state
       setTotalPotGoldCoins(undefined);
@@ -160,7 +155,6 @@ export const StreamContent = ({
       setLoading(false);
 
       // Invalidate cached queries to fetch fresh data from server
-      // This ensures we display the latest round and betting information
       queryClient.invalidateQueries({ queryKey: ['bettingData', streamId, session?.id] });
       queryClient.invalidateQueries({ queryKey: ['selectedRoundData'] });
     };

--- a/src/components/stream/StreamContent.tsx
+++ b/src/components/stream/StreamContent.tsx
@@ -139,6 +139,10 @@ export const StreamContent = ({
     if (!socketInstance) return;
 
     const resetBetData = () => {
+      // Invalidate queries to get fresh data
+      queryClient.invalidateQueries({ queryKey: ['bettingData', streamId, session?.id] });
+      queryClient.invalidateQueries({ queryKey: ['selectedRoundData'] });
+      // Reset UI
       setTotalPotGoldCoins(undefined);
       setTotalPotSweepCoins(undefined);
       setPlaceBet(true);
@@ -150,10 +154,11 @@ export const StreamContent = ({
       setLockedOptions(false);
       setLockedBet(false);
       setUpdatedCurrency(undefined);
-      refetchBettingData();
-      refetchRoundData();
       setIsEditing(false);
       setLoading(false);
+      // Get fresh data
+      refetchBettingData();
+      refetchRoundData();
     };
 
     socketInstance.on('scheduledStreamUpdatedToLive', () => {


### PR DESCRIPTION
This pull request improves the way local betting state and cached data are reset when a stream goes live. The main change is replacing manual data refetching with query invalidation to ensure fresh data is fetched from the server.

Betting state reset improvements:

* Added comments and clarified that all local betting state is cleared in the `resetBetData` function in `StreamContent.tsx`.

Query management enhancements:

* Replaced manual calls to `refetchBettingData` and `refetchRoundData` with `queryClient.invalidateQueries` to invalidate relevant cached queries, ensuring up-to-date data is loaded from the server.