### PR TITLE
auto-populate betting rounds with default options

### DIFF
--- a/src/components/admin/AdminManagement.tsx
+++ b/src/components/admin/AdminManagement.tsx
@@ -479,7 +479,21 @@ export const AdminManagement = ({
       setDescription(streamData?.description);
       setEmbeddedUrl(streamData?.embeddedUrl);
       setCreatorId(streamData.creatorId);
-      setBettingRounds(streamData?.rounds || []);
+      
+      // Auto-populate first round with 2 options if no rounds exist
+      const rounds = streamData?.rounds || [];
+      if (rounds.length === 0) {
+        setBettingRounds([{
+          roundName: 'First round',
+          options: [
+            { option: 'Option 1' },
+            { option: 'Option 2' }
+          ]
+        }]);
+      } else {
+        setBettingRounds(rounds);
+      }
+      
       setIsLiveStream(streamData?.status === StreamStatus.LIVE);
 
       // Set thumbnail if available
@@ -686,6 +700,19 @@ export const AdminManagement = ({
       });
       return;
     }
+    
+    // Auto-populate first round with 2 options if empty
+    if (bettingRounds.length === 0) {
+      const firstRound: BettingRound = {
+        roundName: 'First round',
+        options: [
+          { option: 'Option 1' },
+          { option: 'Option 2' }
+        ]
+      };
+      setBettingRounds([firstRound]);
+    }
+    
     setCreateStep('betting');
   };
 
@@ -745,7 +772,10 @@ export const AdminManagement = ({
 
     const newRound: BettingRound = {
       roundName: defaultName,
-      options: [],
+      options: [
+        { option: 'Option 1' },
+        { option: 'Option 2' }
+      ],
     };
 
     handleRoundsChange([...bettingRounds, newRound]);

--- a/src/components/admin/BettingRounds.tsx
+++ b/src/components/admin/BettingRounds.tsx
@@ -64,6 +64,21 @@ export function BettingRounds({
   const optionRefs = useRef<Array<Array<HTMLTableRowElement | null>>>([]);
   const [lastAddedOption, setLastAddedOption] = useState<{ roundIndex: number; optionId: string } | null>(null);
 
+  // Auto-expand first round if it's the only round, and auto-expand any newly added rounds
+  useEffect(() => {
+    if (rounds.length === 1 && !expandedRounds.includes('round-0')) {
+      setExpandedRounds(['round-0']);
+    } else if (rounds.length > prevRoundsLength.current) {
+      // A new round was added, expand it
+      const newRoundIndex = rounds.length - 1;
+      const newRoundValue = `round-${newRoundIndex}`;
+      if (!expandedRounds.includes(newRoundValue)) {
+        setExpandedRounds(prev => [...prev, newRoundValue]);
+      }
+    }
+    prevRoundsLength.current = rounds.length;
+  }, [rounds.length, expandedRounds]);
+
   // Auto-scroll to bottom after a new round is added
   useEffect(() => {
     if (rounds.length > prevRoundsLength.current) {
@@ -76,7 +91,6 @@ export function BettingRounds({
         }
       }, 500);
     }
-    prevRoundsLength.current = rounds.length;
   }, [rounds.length]);
 
   const addNewRound = () => {
@@ -86,7 +100,10 @@ export function BettingRounds({
     
     const newRound: BettingRound = {
       roundName: defaultName,
-      options: []
+      options: [
+        { option: 'Option 1' },
+        { option: 'Option 2' }
+      ]
     };
     
     onRoundsChange([...rounds, newRound]);


### PR DESCRIPTION
This pull request improves the user experience when managing betting rounds in the admin panel by ensuring that new rounds are automatically populated with default options and that the UI expands to show newly added rounds. The main changes focus on auto-populating and auto-expanding betting rounds to streamline the setup process.

**Betting Round Initialization and Defaults:**

* When loading or creating a stream, if no betting rounds exist, the first round is automatically created with two default options: "Option 1" and "Option 2". [[1]](diffhunk://#diff-1234409323881471ea5909d87ddcadb28093fe3926259c851b0065d6ae20227eL482-R496) [[2]](diffhunk://#diff-1234409323881471ea5909d87ddcadb28093fe3926259c851b0065d6ae20227eR703-R715)
* When adding a new betting round, it is initialized with the same two default options instead of starting empty. [[1]](diffhunk://#diff-1234409323881471ea5909d87ddcadb28093fe3926259c851b0065d6ae20227eL748-R778) [[2]](diffhunk://#diff-7dc968e8de79939ec6940ee82e4df56e3bd8fa86f0ef1f55a3425e213136baacL89-R106)

**User Interface Improvements:**

* The first round is automatically expanded in the UI if it's the only round, and any newly added rounds are auto-expanded to make editing easier for the admin.
* Refactored the logic to ensure the previous rounds length is only updated in the relevant effect, preventing redundant updates.