### PR TITLE
HOT FIX: Remove event type from payload when editing a stream

### DIFF
--- a/src/components/admin/AdminManagement.tsx
+++ b/src/components/admin/AdminManagement.tsx
@@ -704,7 +704,7 @@ export const AdminManagement = ({
       thumbnailUrl: thumbnailImageUrl,
       scheduledStartTime: formatDateTimeForISO(startDateObj, startTime),
       creatorId,
-      type: eventType.value,
+      ...(!editStreamId && { type: eventType.value }),
     };
 
     createStreamMutation.mutate(payload);


### PR DESCRIPTION
This pull request introduces a minor improvement to the stream creation logic in the `AdminManagement` component. The change ensures that the `type` property is only included in the payload when creating a new stream, and not when editing an existing stream.

* Only include the `type` property in the stream creation payload if a new stream is being created, by conditionally spreading the property based on the absence of `editStreamId` in `AdminManagement.tsx`.