### PR TITLE
Fix/delete bet var button and non-vid getting converted to livestream

### DIFF
--- a/src/components/admin/AdminManagement.tsx
+++ b/src/components/admin/AdminManagement.tsx
@@ -244,6 +244,12 @@ export const AdminManagement = ({
     setIsUploading(false);
     setIsLiveStream(false);
 
+    // Reset event type to default
+    setEventType({
+      value: 'stream',
+      label: 'Livestream',
+    });
+
     // Reset betting rounds
     setBettingRounds([]);
 
@@ -504,6 +510,14 @@ export const AdminManagement = ({
       setDescription(streamData?.description);
       setEmbeddedUrl(streamData?.embeddedUrl);
       setCreatorId(streamData.creatorId);
+
+      // Set event type based on stream data
+      if (streamData.streamType) {
+        setEventType({
+          value: streamData.streamType,
+          label: streamData.streamType === 'stream' ? 'Livestream' : 'Non Video'
+        });
+      }
 
       // Auto-populate first round with 2 options if no rounds exist
       const rounds = streamData?.rounds || [];

--- a/src/components/admin/BettingRounds.tsx
+++ b/src/components/admin/BettingRounds.tsx
@@ -418,7 +418,7 @@ export function BettingRounds({
                               </TableCell>
                               <TableCell className="border-t border-b border-[#191D24] p-0 w-14" style={{ borderRadius: 0, width: 56, borderTopWidth: 1, borderBottomWidth: 1, borderColor: '#191D24' }}>
                                 <div className="flex items-center justify-center h-full" style={{ minHeight: 72 }}>
-                                  <Button
+                                  <DeleteBettingDialog
                                     title="Delete Option"
                                     message={`Delete this option from round ${round.roundName}`}
                                     onConfirm={() => deleteOption(roundIndex, optionIndex)}


### PR DESCRIPTION
This pull request makes improvements to the admin management interface, focusing on resetting and initializing the event type state and updating the betting rounds UI. The most notable changes are the addition of logic to reset and set the event type appropriately when managing streams, and a UI update for deleting betting options.

**Event type state management:**

* When resetting the admin management form, the `eventType` state is now reset to the default value of 'Livestream'.
* When loading stream data, the `eventType` is set based on the `streamType` property from the loaded data, mapping the value to the correct label.

**Betting rounds UI update:**

* The delete option button in the betting rounds table has been replaced with a `DeleteBettingDialog` component, likely to provide a confirmation dialog before deleting an option.