### PR TITLE
Fix/toasts

### DIFF
--- a/src/components/stream/BetTokens.tsx
+++ b/src/components/stream/BetTokens.tsx
@@ -167,7 +167,7 @@ export default function BetTokens({
     if (lockedOptions) {
       toast({
         variant: 'destructive',
-        description: 'Admin has locked the picks round',
+        description: 'Admin has locked the round',
       });
       return;
     }
@@ -273,13 +273,13 @@ export default function BetTokens({
             if (Number(sliderMax) === 0) {
               toast({
                 variant: 'destructive',
-                description: 'No coins available to pick',
+                description: 'No coins available to Pick',
               });
             }
             if (lockedOptions) {
               toast({
                 variant: 'destructive',
-                description: 'Admin has locked the picks round',
+                description: 'Admin has locked the round',
               });
             }
           }}

--- a/src/components/stream/QuickPickModalComponents.tsx
+++ b/src/components/stream/QuickPickModalComponents.tsx
@@ -31,7 +31,7 @@ export const NoBettingData = () => {
         />
       </div>
       <p className="text-2xl text-[rgba(255, 255, 255, 1)] text-center pt-4 pb-4 font-bold">
-        No picking options available
+        No Picks available
       </p>
     </div>
   );

--- a/src/components/stream/QuickPickModalComponents.tsx
+++ b/src/components/stream/QuickPickModalComponents.tsx
@@ -26,7 +26,7 @@ export const NoBettingData = () => {
       <div className="all-center flex justify-center items-center h-[100px] mt-8">
         <img
           src="/icons/nobettingData.svg"
-          alt="no picking data"
+          alt="no picks available"
           className="w-[100%] h-[100%] object-contain"
         />
       </div>

--- a/src/hooks/useBettingSocket.ts
+++ b/src/hooks/useBettingSocket.ts
@@ -196,11 +196,6 @@ export function useBettingSocket({
 
     // Handle winner declaration
     const handleWinnerDeclared = (data: any) => {
-      toast({
-        title: 'Round Closed',
-        description: `${data?.winnerName} has been selected as winning pick option!`,
-        duration: 7000,
-      });
       // Refetch queries to get updated data
       refetchBettingData();
       refetchRoundData();
@@ -229,14 +224,22 @@ export function useBettingSocket({
         setIsLoading(false);
 
         if (update?.message) {
-          toast({ description: update.message });
+          toast({
+            id: 'bet-placed',
+            description: update.message
+          });
         }
       }
     };
 
     // Handle new round opened
     const handleBetOpened = () => {
-      toast({ description: 'New Pick options available!' });
+      // Toast removed because rounds now automatically open when created
+      // Uncomment below if notification is needed in the future
+      // toast({
+      //   id: 'bet-opened',
+      //   description: 'New Pick options available!'
+      // });
       refetchBettingData();
       refetchRoundData();
     };
@@ -244,7 +247,8 @@ export function useBettingSocket({
     // Handle bet cancelled by admin
     const handleBetCancelledByAdmin = () => {
       toast({
-        description: 'Current picking round cancelled by admin.',
+        id: 'bet-cancelled-by-admin',
+        description: 'Current round cancelled by admin.',
         variant: 'destructive'
       });
       queryClient.invalidateQueries({ queryKey: ['session'] });
@@ -270,7 +274,10 @@ export function useBettingSocket({
         setIsEditing(false);
 
         if (update?.message) {
-          toast({ description: update?.message });
+          toast({
+            id: 'bet-cancelled',
+            description: update?.message
+          });
         }
 
         refetchBettingData();
@@ -299,7 +306,10 @@ export function useBettingSocket({
         setIsLoading(false);
 
         if (update?.message) {
-          toast({ description: update.message });
+          toast({
+            id: 'bet-edited',
+            description: update.message
+          });
         }
       }
     };
@@ -307,6 +317,7 @@ export function useBettingSocket({
     // Handle errors
     const handleError = (error: any) => {
       toast({
+        id: 'betting-error',
         description: error?.message || 'An error occurred. Please refresh and try again.',
         variant: 'destructive',
       });


### PR DESCRIPTION
This pull request focuses on improving the clarity and consistency of user-facing messages and toast notifications in the betting and quick pick components. It also introduces unique IDs to toast notifications for better management and removes some redundant notifications to streamline the user experience.

**Toast notification improvements:**

* Added unique `id` fields to toast notifications in `useBettingSocket` for actions like placing, cancelling, and editing bets, as well as for error messages. This makes it easier to manage and avoid duplicate toasts. [[1]](diffhunk://#diff-2babfafde58dbb9eea186ba1f6374190d970aa9098cd13597f3bb25f3d6a64d3L232-R251) [[2]](diffhunk://#diff-2babfafde58dbb9eea186ba1f6374190d970aa9098cd13597f3bb25f3d6a64d3L273-R280) [[3]](diffhunk://#diff-2babfafde58dbb9eea186ba1f6374190d970aa9098cd13597f3bb25f3d6a64d3L302-R320)
* Removed the toast notification for when a new betting round opens, since rounds now auto-open and the notification is no longer necessary.

**User-facing message consistency:**

* Updated various toast descriptions and UI messages in `BetTokens.tsx` and `QuickPickModalComponents.tsx` to use consistent and clearer language (e.g., "Admin has locked the round", "No Picks available", "Current round cancelled by admin."). [[1]](diffhunk://#diff-c62a5a4284a5ac7e50c61627131b30f6554b40baf0dbce7a2d414d56cd77e0aaL170-R170) [[2]](diffhunk://#diff-c62a5a4284a5ac7e50c61627131b30f6554b40baf0dbce7a2d414d56cd77e0aaL276-R282) [[3]](diffhunk://#diff-80b83323b3b00cb598fee4d90a0f7ed57f4c7a015f8b09f86c6927b5550bc1d2L29-R34) [[4]](diffhunk://#diff-2babfafde58dbb9eea186ba1f6374190d970aa9098cd13597f3bb25f3d6a64d3L232-R251)

**Redundant notification removal:**

* Removed the toast notification when a winner is declared, reducing unnecessary user interruptions.