### PR TITLE
highlight joshcapopashot's Instagram profile in the user profile comp…

### DIFF
--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -91,6 +91,11 @@ export default function Profile() {
                           
                           if (!profileSocial) return null;
 
+                          const isJoshCapoInstagram = 
+                            social === 'instagram' && 
+                            username === 'joshcapopashot' && 
+                            profileSocial === 'https://www.instagram.com/joshcapopashot?igsh=eWtsb2p4ZWxqZ3Jk&utm_source=qr';
+
                           return (
                             <div key={social} className='flex gap-1 text-white items-center text-sm'>
                               {socialsMapping[social].icon}
@@ -104,6 +109,7 @@ export default function Profile() {
                               >
                                 {profileSocial}
                               </a>
+                              {isJoshCapoInstagram && <span className="text-muted-foreground"> &lt;-- Live Here</span>}
                             </div>
                           )
                         })}


### PR DESCRIPTION
This pull request introduces a special visual indicator for a specific Instagram profile link in the `Profile` component. When the profile's Instagram username and URL match a particular value, a "Live Here" label is displayed next to the link.

Conditional UI enhancement:

* Added logic in `Profile.tsx` to check if the social link is Instagram, the username is `joshcapopashot`, and the URL matches a specific string; if so, displays a "Live Here" label next to the link. [[1]](diffhunk://#diff-991fd67e5b3fed788072c54ea29e8c8635869a9ad427430130fb06cfe8f4199bR94-R98) [[2]](diffhunk://#diff-991fd67e5b3fed788072c54ea29e8c8635869a9ad427430130fb06cfe8f4199bR112)…onent