### PR TITLE
Fix/admin round stats

### DIFF
--- a/src/components/admin/AdminBettingRoundsCard.tsx
+++ b/src/components/admin/AdminBettingRoundsCard.tsx
@@ -91,6 +91,26 @@ export const AdminBettingRoundsCard = ({
     );
   }, [betData]);
 
+  // Merge WebSocket betting updates into rounds state
+  useEffect(() => {
+    if (bettingUpdate && bettingUpdate.roundId) {
+      setRounds(prevRounds =>
+        prevRounds.map(round => {
+          if (round.roundId === bettingUpdate.roundId) {
+            return {
+              ...round,
+              totalGoldCoinBet: bettingUpdate.totalGoldCoinBet ?? round.totalGoldCoinBet,
+              totalBetsGoldCoinAmount: bettingUpdate.totalBetsGoldCoinAmount ?? round.totalBetsGoldCoinAmount,
+              totalSweepCoinBet: bettingUpdate.totalSweepCoinBet ?? round.totalSweepCoinBet,
+              totalBetsSweepCoinAmount: bettingUpdate.totalBetsSweepCoinAmount ?? round.totalBetsSweepCoinAmount,
+            };
+          }
+          return round;
+        })
+      );
+    }
+  }, [bettingUpdate]);
+
   // Find active round index
   const activeIdx = useMemo(() => getActiveRoundIndex(rounds), [rounds]);
 
@@ -290,6 +310,7 @@ export const AdminBettingRoundsCard = ({
                     errorRounds={bettingErrorRounds}
                     onErrorRoundsChange={setBettingErrorRounds}
                     validationErrors={bettingValidationErrors}
+                    eventType={streamInfo?.eventType}
                   />
                 </div>
               </DialogContent>
@@ -401,18 +422,14 @@ export const AdminBettingRoundsCard = ({
                                   <div className="flex items-center gap-1 mb-2 text-white text-sm font-medium">
                                     <img src="/icons/Users.svg" alt="Users" className="w-4 h-4" />
                                     <span>
-                                      {bettingUpdate
-                                        ? bettingUpdate?.totalGoldCoinBet
-                                        : streamInfo?.totalGoldCoinBet}{' '}
+                                      {round.totalGoldCoinBet ?? 0}{' '}
                                       gold(s)
                                     </span>
                                   </div>
                                   <div className="flex items-center gap-1 text-yellow-400 text-sm font-medium">
                                     <img src="/icons/coin.svg" alt="Coins" className="w-4 h-4" />
                                     <span>
-                                      {bettingUpdate
-                                        ? bettingUpdate?.totalBetsGoldCoinAmount
-                                        : streamInfo?.totalGoldCoinAmount}
+                                      {round.totalBetsGoldCoinAmount ?? 0}
                                     </span>
                                   </div>
                                 </div>
@@ -420,18 +437,14 @@ export const AdminBettingRoundsCard = ({
                                   <div className="flex items-center gap-1 mb-2 text-white text-sm font-medium">
                                     <img src="/icons/Users.svg" alt="Users" className="w-4 h-4" />
                                     <span>
-                                      {bettingUpdate
-                                        ? bettingUpdate?.totalSweepCoinBet
-                                        : streamInfo?.totalSweepCoinBet}{' '}
+                                      {round.totalSweepCoinBet ?? 0}{' '}
                                       Stream Coin(s)
                                     </span>
                                   </div>
                                   <div className="flex items-center gap-1 text-yellow-400 text-sm font-medium">
                                     <img src="/icons/coin.svg" alt="Coins" className="w-4 h-4" />
                                     <span>
-                                      {bettingUpdate
-                                        ? bettingUpdate?.totalBetsSweepCoinAmount
-                                        : streamInfo?.totalSweepCoinAmount}
+                                      {round.totalBetsSweepCoinAmount ?? 0}
                                     </span>
                                   </div>
                                 </div>

--- a/src/components/admin/AdminBettingRoundsCard.tsx
+++ b/src/components/admin/AdminBettingRoundsCard.tsx
@@ -99,9 +99,9 @@ export const AdminBettingRoundsCard = ({
           if (round.roundId === bettingUpdate.roundId) {
             return {
               ...round,
-              totalGoldCoinBet: bettingUpdate.totalGoldCoinBet ?? round.totalGoldCoinBet,
+              betCountGoldCoin: bettingUpdate.betCountGoldCoin ?? round.betCountGoldCoin,
               totalBetsGoldCoinAmount: bettingUpdate.totalBetsGoldCoinAmount ?? round.totalBetsGoldCoinAmount,
-              totalSweepCoinBet: bettingUpdate.totalSweepCoinBet ?? round.totalSweepCoinBet,
+              betCountSweepCoin: bettingUpdate.betCountSweepCoin ?? round.betCountSweepCoin,
               totalBetsSweepCoinAmount: bettingUpdate.totalBetsSweepCoinAmount ?? round.totalBetsSweepCoinAmount,
             };
           }
@@ -422,7 +422,7 @@ export const AdminBettingRoundsCard = ({
                                   <div className="flex items-center gap-1 mb-2 text-white text-sm font-medium">
                                     <img src="/icons/Users.svg" alt="Users" className="w-4 h-4" />
                                     <span>
-                                      {round.totalGoldCoinBet ?? 0}{' '}
+                                      {round.betCountGoldCoin ?? 0}{' '}
                                       gold(s)
                                     </span>
                                   </div>
@@ -437,7 +437,7 @@ export const AdminBettingRoundsCard = ({
                                   <div className="flex items-center gap-1 mb-2 text-white text-sm font-medium">
                                     <img src="/icons/Users.svg" alt="Users" className="w-4 h-4" />
                                     <span>
-                                      {round.totalSweepCoinBet ?? 0}{' '}
+                                      {round.betCountSweepCoin ?? 0}{' '}
                                       Stream Coin(s)
                                     </span>
                                   </div>


### PR DESCRIPTION
Note: 
- This goes with api PR https://github.com/Streambet-LLC/streambet_api/pull/62
- Also note that I added 'eventType' on ln 313 to fix an error in the AdminBettingRoundsCard.tsx file.

This pull request enhances the `AdminBettingRoundsCard` component to better handle real-time updates and display of betting round data. The main improvements include integrating WebSocket betting updates directly into the rounds state and simplifying how betting statistics are rendered in the UI.

**Real-time updates and state management:**

* Added a `useEffect` hook to merge incoming WebSocket betting updates (`bettingUpdate`) into the local `rounds` state, ensuring the UI reflects the latest data for each round.

**UI and data display improvements:**

* Updated the display logic for betting statistics to use the values from each `round` object (`betCountGoldCoin`, `totalBetsGoldCoinAmount`, `betCountSweepCoin`, `totalBetsSweepCoinAmount`) instead of conditionally checking `bettingUpdate` or `streamInfo`, which simplifies the code and ensures consistency with the updated state.
* Passed `eventType` from `streamInfo` as a prop to a child component, potentially enabling more context-aware rendering or validation.