### PR TITLE
fix: replace fragment with div in AuthLayout for proper structure

### DIFF
--- a/src/components/layout/AuthLayout.tsx
+++ b/src/components/layout/AuthLayout.tsx
@@ -9,7 +9,7 @@ interface AuthLayoutProps {
 
 export const AuthLayout = ({ children, title, subtitle }: AuthLayoutProps) => {
   return (
-    <>
+    <div className='h-screen overflow-auto'>
       <div className="auth-bg-gradient" />
       <div className="container flex justify-center min-h-screen pt-16 pb-8">
         <div className="w-full max-w-md">
@@ -39,6 +39,6 @@ export const AuthLayout = ({ children, title, subtitle }: AuthLayoutProps) => {
       >
         © Streambet 2025
       </div>
-    </>
+    </div>
   );
 }; 


### PR DESCRIPTION
This pull request makes a small update to the `AuthLayout` component to improve its layout and scrolling behavior. The main change is wrapping the layout in a `div` with `h-screen overflow-auto` to ensure the authentication pages use the full viewport height and allow scrolling when needed.

- Layout improvement:
  * Wrapped the entire `AuthLayout` content in a `div` with `h-screen overflow-auto` to ensure full viewport height and enable scrolling for content that overflows. (`src/components/layout/AuthLayout.tsx`) [[1]](diffhunk://#diff-2f0889502a7c6a7cb385881f05d721beba420ad56cdb77e84325b0ab26dcb221L12-R12) [[2]](diffhunk://#diff-2f0889502a7c6a7cb385881f05d721beba420ad56cdb77e84325b0ab26dcb221L42-R42)