### PR TITLE
Update placeholder text for title and description fields in StreamInfoForm

### DIFF
--- a/src/components/admin/StreamInfoForm.tsx
+++ b/src/components/admin/StreamInfoForm.tsx
@@ -179,7 +179,7 @@ export const StreamInfoForm = ({
         <Label className="text-white font-light mb-3 block">Title</Label>
         <Input
           className={`bg-[#272727] text-[#D7DFEF] placeholder:text-[#D7DFEF60] mt-2 ${errors.title ? 'border border-red-500' : 'border-none'}`}
-          placeholder="Title of event"
+          placeholder="Title of Event -- Format Guidance: 'Event Name - Bet'"
           value={initialValues.title}
           maxLength={STREAM_LIMITS.TITLE_MAX_LENGTH}
           minLength={STREAM_LIMITS.TITLE_MIN_LENGTH}
@@ -197,7 +197,7 @@ export const StreamInfoForm = ({
         <Label className="text-white font-light mb-3 block">Description</Label>
         <Textarea
           className={`bg-[#272727] text-[#D7DFEF] placeholder:text-[#D7DFEF60] mt-2 ${errors.description ? 'border border-red-500' : 'border-none'}`}
-          placeholder="Stream description"
+          placeholder="Description -- describe your event in more detail; whatever you think is most pertinent"
           rows={10}
           value={initialValues.description}
           onChange={e => {


### PR DESCRIPTION
This pull request updates the placeholder text in the `StreamInfoForm` component to provide clearer guidance for users when entering event titles and descriptions.

Improvements to user input guidance:

* Updated the `title` input's placeholder to give explicit format guidance: "Title of Event -- Format Guidance: 'Event Name - Bet'" (`src/components/admin/StreamInfoForm.tsx`)
* Updated the `description` textarea's placeholder to encourage more detailed and pertinent event descriptions: "Description -- describe your event in more detail; whatever you think is most pertinent" (`src/components/admin/StreamInfoForm.tsx`)