### PR TITLE
hot fix: Implement priority-based sorting for bets and add client-side pagination

### DIFF
--- a/src/components/home/HomeBets.tsx
+++ b/src/components/home/HomeBets.tsx
@@ -5,9 +5,14 @@ import { Button } from '../ui/button';
 import { Skeleton } from '../ui/skeleton';
 import { Loader2 } from 'lucide-react';
 import { useStreamPromotionListener } from '@/hooks/useStreamPromotionListener';
+import { useEffect, useMemo, useState } from 'react';
+import { PRIORITY_STREAMS } from '@/utils/constants';
+import { sortByPriorityPairs } from '@/utils/helper';
 
 export default function HomeBets() {
-  const { data, hasNextPage, fetchNextPage, isLoading, refetch } = useInfiniteQuery({
+  const [displayCount, setDisplayCount] = useState(24);
+  
+  const { data, hasNextPage, fetchNextPage, isLoading, isFetchingNextPage, refetch } = useInfiniteQuery({
     queryKey: ['homepage-bets'],
     queryFn: async ({ pageParam }) => {
       const response = await api.bets.getBets({ page: pageParam });
@@ -18,7 +23,26 @@ export default function HomeBets() {
     getNextPageParam: lastPage => (lastPage.hasNextPage ? lastPage.page + 1 : undefined),
   });
 
-  const bets = data?.pages.map(({ data: bets }) => bets || [])?.flat() || [];
+  // Auto-fetch all pages in background for proper sorting
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  // Get all bets and sort by priority pairs
+  const sortedBets = useMemo(() => {
+    const allBets = data?.pages.map(({ data: bets }) => bets || [])?.flat() || [];
+    return sortByPriorityPairs(allBets, PRIORITY_STREAMS);
+  }, [data]);
+
+  // Display only first N items (client-side pagination)
+  const displayedBets = sortedBets.slice(0, displayCount);
+  const hasMore = displayCount < sortedBets.length;
+
+  const handleLoadMore = () => {
+    setDisplayCount(prev => prev + 24);
+  };
 
   // Listen for stream promotion updates
   useStreamPromotionListener(refetch);
@@ -34,14 +58,14 @@ export default function HomeBets() {
             ? Array(24)
                 .fill('')
                 .map((_, i) => <Skeleton key={i} className="w-full h-64" />)
-            : bets?.map((bet, i) => <BetCard key={i} {...bet} />)}
+            : displayedBets?.map((bet, i) => <BetCard key={i} {...bet} />)}
         </div>
-        {hasNextPage && (
+        {hasMore && (
           <Button
             disabled={isLoading}
             variant="outline"
             className="mx-auto"
-            onClick={() => fetchNextPage()}
+            onClick={handleLoadMore}
           >
             {isLoading ? (
               <>

--- a/src/components/home/HomePromotedBets.tsx
+++ b/src/components/home/HomePromotedBets.tsx
@@ -11,6 +11,10 @@ import { useQuery } from '@tanstack/react-query';
 import api from '@/integrations/api/client';
 import { Skeleton } from '../ui/skeleton';
 import { useStreamPromotionListener } from '@/hooks/useStreamPromotionListener';
+import { useMemo } from 'react';
+import { PRIORITY_STREAMS } from '@/utils/constants';
+import { sortByPriorityPairs } from '@/utils/helper';
+import { BetCard as BetCardType } from '@/types/bet';
 
 export default function HomePromotedBets() {
   const { data, isLoading, refetch } = useQuery({
@@ -25,6 +29,11 @@ export default function HomePromotedBets() {
   // Listen for stream promotion updates
   useStreamPromotionListener(refetch);
 
+  const sortedData = useMemo(() => {
+    if (!data) return [];
+    return sortByPriorityPairs(data as BetCardType[], PRIORITY_STREAMS);
+  }, [data]);
+
   if (!data) return;
 
   return (
@@ -35,7 +44,7 @@ export default function HomePromotedBets() {
           {isLoading ? (
             <Skeleton className="flex-1 w-full h-64 rounded-none" />
           ) : (
-            data?.map((bet, i) => (
+            sortedData?.map((bet, i) => (
               <CarouselItem key={i}>
                 <BetCard {...bet} />
               </CarouselItem>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1956,4 +1956,28 @@ export const STREAM_LIMITS = {
   DESCRIPTION_MAX_CHARACTERS: 300,
   DESCRIPTION_MAX_WORDS: 50,
 } as const;
-  
+
+// Priority order for betting rounds on landing page
+// Streams matching these creator/title pairs (case-insensitive) will display first
+// in the order specified here. Add or reorder pairs as needed.
+export const PRIORITY_STREAMS: Array<{
+  creatorUsername: string;
+  bettingRoundTitle: string;
+}> = [
+  {
+    creatorUsername: "TinyTrackCars",
+    bettingRoundTitle: "BMW vs Subaru: Overall Winner?"
+  },
+  {
+    creatorUsername: "joshcapopashot",
+    bettingRoundTitle: "BLINDFOLDED Josh Caputo Popashot: Over/Under 99.5 points"
+  },
+  {
+    creatorUsername: "ZonaEats",
+    bettingRoundTitle: "Will Zona Eat 3 Big Macs in Over / Under 60 Seconds"
+  },
+  {
+    creatorUsername: "Qb54",
+    bettingRoundTitle: "First round"
+  },
+];

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -254,3 +254,46 @@ export const isImageSFW = async (url: string) => {
     };
   });
 }
+
+/**
+ * Sort items by priority creator/title pairs.
+ * Matches require BOTH creator username AND betting round title to match.
+ * Items matching pairs appear first in the order specified in the priority list.
+ * Non-matching items appear after, maintaining their original order.
+ * 
+ * @param items - Array of betting rounds/streams with name and creator fields
+ * @param priorityPairs - Array of {creatorUsername, bettingRoundTitle} pairs
+ * @returns Sorted array with prioritized items first
+ */
+export const sortByPriorityPairs = <T extends { 
+  name: string; 
+  creator?: string | null 
+}>(
+  items: T[],
+  priorityPairs: Array<{ creatorUsername: string; bettingRoundTitle: string }>
+): T[] => {
+  if (!priorityPairs || priorityPairs.length === 0) {
+    return items; // No sorting if priority list is empty
+  }
+
+  // Create a map of "creator|title" -> priority index
+  const priorityMap = new Map(
+    priorityPairs.map((pair, index) => {
+      const key = `${pair.creatorUsername.toLowerCase().trim()}|${pair.bettingRoundTitle.toLowerCase().trim()}`;
+      return [key, index];
+    })
+  );
+  
+  return [...items].sort((a, b) => {
+    const aKey = `${(a.creator || '').toLowerCase().trim()}|${(a.name || '').toLowerCase().trim()}`;
+    const bKey = `${(b.creator || '').toLowerCase().trim()}|${(b.name || '').toLowerCase().trim()}`;
+    
+    const aPriority = priorityMap.get(aKey) ?? Infinity;
+    const bPriority = priorityMap.get(bKey) ?? Infinity;
+    
+    // If both have priority, sort by priority index
+    // If only one has priority, it comes first
+    // If neither has priority, maintain original order (stable sort)
+    return aPriority - bPriority;
+  });
+};


### PR DESCRIPTION
This pull request introduces a new system for prioritizing the display order of betting rounds and streams on the homepage and promoted bets carousel. The main change is the implementation of a priority list that ensures specific creator/title pairs are shown first, in a defined order, followed by all other items. This is achieved through a new sorting utility and updates to the relevant components to use this logic.

**Homepage and promoted bets prioritization:**

* Added a new constant `PRIORITY_STREAMS` in `src/utils/constants.ts` that defines an ordered list of creator/title pairs to be prioritized on the landing page. Streams matching these pairs will be displayed first.
* Implemented a new helper function `sortByPriorityPairs` in `src/utils/helper.ts` that sorts an array of betting rounds/streams so that items matching the priority pairs appear first, in the order specified, followed by all others in their original order.

**Component updates to use prioritization:**

* Updated `HomeBets` (`src/components/home/HomeBets.tsx`) to:
  - Fetch all pages in the background to enable proper sorting across all bets.
  - Use the new sorting logic to order bets according to the priority list.
  - Implement client-side pagination after sorting, so prioritized bets are always shown first, regardless of backend pagination. [[1]](diffhunk://#diff-e129d1cf5ef3e7db708e0368e7b2c32d99043b7edeaa610b0b1087b8a1bde027R8-R15) [[2]](diffhunk://#diff-e129d1cf5ef3e7db708e0368e7b2c32d99043b7edeaa610b0b1087b8a1bde027L21-R45) [[3]](diffhunk://#diff-e129d1cf5ef3e7db708e0368e7b2c32d99043b7edeaa610b0b1087b8a1bde027L37-R68)
* Updated `HomePromotedBets` (`src/components/home/HomePromotedBets.tsx`) to use the new sorting logic, ensuring promoted bets are also prioritized according to the defined pairs. [[1]](diffhunk://#diff-1e5da1120b2c815d06d24f57742c5cc1195bb1611eb019041870d662361728eeR14-R17) [[2]](diffhunk://#diff-1e5da1120b2c815d06d24f57742c5cc1195bb1611eb019041870d662361728eeR32-R36) [[3]](diffhunk://#diff-1e5da1120b2c815d06d24f57742c5cc1195bb1611eb019041870d662361728eeL38-R47)