### PR TITLE
Enhance stream status badges and scheduling UI

### DIFF
--- a/src/components/BetCard.tsx
+++ b/src/components/BetCard.tsx
@@ -7,7 +7,8 @@ import { Link } from 'react-router-dom';
 import { Video } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { QuickPickModal } from './stream/QuickPickModal';
-import { BettingRoundStatus } from '@/enums';
+import { BettingRoundStatus, StreamStatus } from '@/enums';
+import { StreamStatusBadge } from '@/components/stream/StreamStatusBadge';
 import api from '@/integrations/api/client';
 
 export default function BetCard(props: BetCardType) {
@@ -108,21 +109,32 @@ export default function BetCard(props: BetCardType) {
     <Card
       className={`${wiggle && 'wiggle'} h-full flex flex-col border border-gray-600 shadow-lg overflow-hidden ${(statuses.isForStream || statuses.isOpen || statuses.isCreated) && 'border-[#BDFF00]'}`}
     >
-      <CardHeader className="p-4 pb-0 flex flex-row gap-3 items-center h-16">
-        <img
-          src={getThumbnailUrl(cardData.thumbnail)}
-          className="aspect-square w-9 h-9 rounded-md"
-        />
-        <div className="flex items-center gap-2">
-          <CardTitle
-            onClick={statuses.canOpen ? handleClick : undefined}
-            className={cn(
-              'text-md line-clamp-2',
-              statuses.canOpen ? 'cursor-pointer hover:underline' : 'cursor-not-allowed opacity-70'
-            )}
-          >
-            {cardData.name}
-          </CardTitle>
+      <CardHeader className="p-4 pb-0 flex flex-col gap-3">
+        {cardData.streamStatus === StreamStatus.SCHEDULED && (
+          <div className="flex justify-start">
+            <StreamStatusBadge 
+              status={StreamStatus.SCHEDULED}
+              scheduledStartTime={cardData.scheduledStartTime}
+              multiline={false}
+              isStreamType={cardData.type === 'stream'}
+            />
+          </div>
+        )}
+        <div className="flex flex-row gap-3 items-center">
+          <img
+            src={getThumbnailUrl(cardData.thumbnail)}
+            className="aspect-square w-9 h-9 rounded-md"
+          />
+          <div className="flex items-center gap-2">
+            <CardTitle
+              onClick={statuses.canOpen ? handleClick : undefined}
+              className={cn(
+                'text-md line-clamp-2',
+                statuses.canOpen ? 'cursor-pointer hover:underline' : 'cursor-not-allowed opacity-70'
+              )}
+            >
+              {cardData.name}
+            </CardTitle>
           {(statuses.isLocked ||
             statuses.isEnded ||
             statuses.isCancelled ||
@@ -162,6 +174,7 @@ export default function BetCard(props: BetCardType) {
                     : 'Locked'}
             </span>
           )}
+          </div>
         </div>
       </CardHeader>
       <CardContent className="flex-1 flex flex-col gap-2 p-4">
@@ -211,7 +224,7 @@ export default function BetCard(props: BetCardType) {
                     'ml-1 px-2 py-0.5 rounded-full text-xs font-semibold border bg-[#2a2a2a] text-white border-red-500/40'
                   )}
                 >
-                  Winner!
+                  ✅ Winning Side
                 </span>
               )}
             </div>

--- a/src/components/admin/StreamInfoForm.tsx
+++ b/src/components/admin/StreamInfoForm.tsx
@@ -398,7 +398,11 @@ export const StreamInfoForm = ({
       </div>
       {/* Start date */}
       <div>
-        <Label className="text-white font-light mb-3 block">Start date & time</Label>
+        <Label className="text-white font-light mb-3 block">
+          {initialValues.eventType.value === 'stream' 
+            ? 'Start date & time' 
+            : 'Date & Time that Picks Will Be Locked'}
+        </Label>
         <Popover>
           <PopoverTrigger asChild>
             <button
@@ -427,7 +431,9 @@ export const StreamInfoForm = ({
                 {initialValues.startDateObj
                   ? initialValues.startDateObj.toLocaleDateString() +
                     (initialValues.startTime ? ` ${formatTime12hr(initialValues.startTime)}` : '')
-                  : 'Pick a date & time'}
+                  : initialValues.eventType.value === 'stream'
+                    ? 'Select a date & time'
+                    : 'Select a lock date & time'}
               </span>
               {!isLive && (initialValues.startDateObj || initialValues.startTime) && (
                 <button

--- a/src/components/home/HomePromotedBets.tsx
+++ b/src/components/home/HomePromotedBets.tsx
@@ -10,7 +10,6 @@ import BetCard from '../BetCard';
 import { useQuery } from '@tanstack/react-query';
 import api from '@/integrations/api/client';
 import { Skeleton } from '../ui/skeleton';
-import { useState } from 'react';
 import { QuickPickModal } from '../stream/QuickPickModal';
 import { useStreamPromotionListener } from '@/hooks/useStreamPromotionListener';
 import { PRIORITY_STREAMS } from '@/utils/constants';

--- a/src/components/stream/StreamStatusBadge.tsx
+++ b/src/components/stream/StreamStatusBadge.tsx
@@ -7,6 +7,7 @@ interface StreamStatusBadgeProps {
   status: StreamStatus;
   scheduledStartTime?: string;
   multiline?: boolean;
+  isStreamType?: boolean;
 }
 
 // Animation configuration - consistent across all badges
@@ -23,15 +24,19 @@ const ANIMATION_CONFIG = {
 // Badge styling constants
 const BADGE_STYLES = {
   LIVE: {
-    container: 'flex items-center gap-2 bg-red-600 text-white px-2 py-1 rounded-md shadow-lg',
+    container: 'flex items-center gap-2 bg-badge-live text-white px-2 py-1 rounded-md shadow-lg',
     text: 'font-bold text-xs tracking-wider',
   },
-  SCHEDULED: {
-    container: 'flex items-center gap-2 bg-purple-700 text-white px-2 py-1 rounded-md shadow-lg',
+  SCHEDULED_STREAM: {
+    container: 'flex items-center gap-2 bg-badge-scheduled-stream text-white px-2 py-1 rounded-md shadow-lg',
+    text: 'font-medium text-xs',
+  },
+  SCHEDULED_NON_VIDEO: {
+    container: 'flex items-center gap-2 bg-badge-scheduled-non-video text-white px-2 py-1 rounded-md shadow-lg',
     text: 'font-medium text-xs',
   },
   ENDED: {
-    container: 'flex items-center gap-2 px-3 py-1.5 bg-zinc-600/90 backdrop-blur-sm rounded-md text-xs font-bold uppercase tracking-wider shadow-lg',
+    container: 'flex items-center gap-2 px-3 py-1.5 bg-badge-ended/90 backdrop-blur-sm rounded-md text-xs font-bold uppercase tracking-wider shadow-lg',
   },
 } as const;
 
@@ -51,6 +56,7 @@ export const StreamStatusBadge = ({
   status,
   scheduledStartTime,
   multiline = false,
+  isStreamType = true,
 }: StreamStatusBadgeProps) => {
   // LIVE badge with pulsing dot
   if (status === StreamStatus.LIVE) {
@@ -69,22 +75,26 @@ export const StreamStatusBadge = ({
 
   // SCHEDULED badge with calendar icon
   if (status === StreamStatus.SCHEDULED) {
+    const labelPrefix = isStreamType ? 'Stream Upcoming' : 'Picks Close';
     const ariaLabel = scheduledStartTime 
-      ? `Stream upcoming: ${formatDate(scheduledStartTime)} at ${formatTime(scheduledStartTime)}`
-      : 'Stream upcoming: TBA';
+      ? `${labelPrefix}: ${formatDate(scheduledStartTime)} at ${formatTime(scheduledStartTime)}`
+      : `${labelPrefix}: TBA`;
+    
+    // Select appropriate badge style based on bet type
+    const badgeStyle = isStreamType ? BADGE_STYLES.SCHEDULED_STREAM : BADGE_STYLES.SCHEDULED_NON_VIDEO;
     
     return (
       <motion.div {...ANIMATION_CONFIG} role="status" aria-label={ariaLabel}>
-        <div className={BADGE_STYLES.SCHEDULED.container}>
+        <div className={badgeStyle.container}>
           <Calendar className="h-3 w-3" />
-          <span className={BADGE_STYLES.SCHEDULED.text}>
+          <span className={badgeStyle.text}>
             {scheduledStartTime ? (
               <>
-                Stream Upcoming: {multiline && <br />}{formatDate(scheduledStartTime)} at{' '}
+                {isStreamType ? 'Stream Upcoming' : 'Picks Close'}: {multiline && <br />}{formatDate(scheduledStartTime)} at{' '}
                 {formatTime(scheduledStartTime)}
               </>
             ) : (
-              'Stream Upcoming: TBA'
+              isStreamType ? 'Stream Upcoming: TBA' : 'Picks Close: TBA'
             )}
           </span>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -75,6 +75,10 @@
     --input: 0 0% 9%;
     --ring: 94 100% 54%;
     --radius: 0.5rem;
+    --badge-live: 0 84% 60%;
+    --badge-scheduled-stream: 274 87% 60%;
+    --badge-scheduled-non-video: 0 72% 51%;
+    --badge-ended: 240 5% 26%;
   }
 }
 

--- a/src/types/bet.ts
+++ b/src/types/bet.ts
@@ -17,5 +17,7 @@ export interface BetCard {
   streamName: string | null;
   type: string | null;
   status?: string | null;
+  streamStatus?: string | null;
+  scheduledStartTime?: string | null;
   setQuickPick: (streamId: string, roundId: string, streamName: string) => void,
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -68,6 +68,12 @@ export default {
           border: 'hsl(var(--sidebar-border))',
           ring: 'hsl(var(--sidebar-ring))',
         },
+        badge: {
+          live: 'hsl(var(--badge-live))',
+          'scheduled-stream': 'hsl(var(--badge-scheduled-stream))',
+          'scheduled-non-video': 'hsl(var(--badge-scheduled-non-video))',
+          ended: 'hsl(var(--badge-ended))',
+        },
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
Note: 
- This goes with PR https://github.com/Streambet-LLC/streambet_api/pull/86
- Src/components/home/HomePromotedBets.tsx ln 13 was a duplicate useState import error change unrelated to this PR. Looks like you duplicated it on line 18 earlier today when you added useMemo to the import from react.

This pull request introduces several UI improvements to how scheduled streams and bets are displayed, especially focusing on status badges and date/time labeling. The main changes involve enhancing the `BetCard` and `StreamStatusBadge` components to provide clearer information about event timing and status, as well as updating styles to support these improvements.

**UI Enhancements for Scheduled Streams and Bets:**

* `BetCard` now displays a status badge for scheduled events, using the new `StreamStatusBadge` component and passing the appropriate type and timing information. [[1]](diffhunk://#diff-4b2fa285a7aa410025e2e18be6aad42f28ce32fe5e2c9d281d0dbd73ce23b651L10-R11) [[2]](diffhunk://#diff-4b2fa285a7aa410025e2e18be6aad42f28ce32fe5e2c9d281d0dbd73ce23b651L111-R123)
* The winning side label on bet cards has been updated for clarity ("✅ Winning Side" instead of "Winner!").

**Stream Status Badge Improvements:**

* `StreamStatusBadge` now accepts an `isStreamType` prop to distinguish between stream and non-stream events, and uses different badge styles and label prefixes ("Stream Upcoming" vs. "Picks Close") accordingly. [[1]](diffhunk://#diff-e97530164bba407733ca2f2fe2f814cbb6a7400ff767f10ec662d440f9e8b408R10) [[2]](diffhunk://#diff-e97530164bba407733ca2f2fe2f814cbb6a7400ff767f10ec662d440f9e8b408R59) [[3]](diffhunk://#diff-e97530164bba407733ca2f2fe2f814cbb6a7400ff767f10ec662d440f9e8b408R78-R97)
* Badge color variables and Tailwind theme extensions have been added for live, scheduled-stream, scheduled-non-video, and ended statuses, ensuring consistent and distinct visual cues. [[1]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eR78-R81) [[2]](diffhunk://#diff-655dc9e3d0aa561e3fa164bf48bd89cb0f5da65e0a567f8ebbf9dd791a0e7f40R71-R76)

**Form and Label Updates:**

* The stream info form now dynamically changes the label for the date/time picker based on event type, improving clarity for admins setting up events. [[1]](diffhunk://#diff-5cd1a8d0f1b98bdc7d7e3f36db4d4a50a6577239578c09e9eb66fd947c5833bfL401-R405) [[2]](diffhunk://#diff-5cd1a8d0f1b98bdc7d7e3f36db4d4a50a6577239578c09e9eb66fd947c5833bfL430-R436)

**Type and Prop Additions:**

* The `BetCard` type now includes optional `streamStatus` and `scheduledStartTime` fields to support the new badge and scheduling features.

These changes collectively improve the clarity and visual distinction of scheduled events and their statuses throughout the app.