### PR TITLE
Fix/promoted carousel

### DIFF
--- a/src/components/home/HomePromotedBets.tsx
+++ b/src/components/home/HomePromotedBets.tsx
@@ -51,15 +51,24 @@ export default function HomePromotedBets() {
         <Carousel 
           className="flex-1 w-full"
           opts={{
-          align: 'start',
-          loop: false,
-          slidesToScroll: 1,
-          containScroll: 'trimSnaps'
-        }}
-      >
+            align: 'start',
+            loop: false,
+            slidesToScroll: 1,
+            containScroll: 'trimSnaps'
+          }}
+        >
           <CarouselContent className="flex-1">
             {isLoading ? (
-              <Skeleton className="flex-1 w-full h-64 rounded-none" />
+              <>
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <CarouselItem 
+                    key={i}
+                    className="basis-full md:basis-1/2 lg:basis-1/3 pl-4"
+                  >
+                    <Skeleton className="w-full h-64 rounded-lg" />
+                  </CarouselItem>
+                ))}
+              </>
             ) : (
               sortedData?.map((bet) => (
                 <CarouselItem 

--- a/src/components/home/HomePromotedBets.tsx
+++ b/src/components/home/HomePromotedBets.tsx
@@ -46,8 +46,7 @@ export default function HomePromotedBets() {
 
   return (
     <>
-      <div className="text-2xl font-bold pl-2">Featured Streams</div>
-      <div className="rounded-lg p-6 -mx-4 bg-[radial-gradient(ellipse_at_center,_var(--tw-gradient-stops))] from-[#BDFF00]/20 via-zinc-900 via-40% to-background">
+      <div className="p-6 -mx-4 bg-[radial-gradient(ellipse_at_center,_var(--tw-gradient-stops))] from-[#BDFF00]/20 via-zinc-900 via-40% to-background">
         <Carousel 
           className="flex-1 w-full"
           opts={{
@@ -92,12 +91,12 @@ export default function HomePromotedBets() {
           </CarouselContent>
           <div className="flex items-center justify-between pt-4">
             <CarouselPrevious
-              className="relative top-0 left-0 translate-y-[unset] translate-x-[unset]"
+              className="relative top-0 left-0 translate-y-[unset] translate-x-[unset] border-[#BDFF00]"
               size="lg"
             />
             <CarouselDots className="relative" />
             <CarouselNext
-              className="relative top-0 left-0 translate-y-[unset] translate-x-[unset]"
+              className="relative top-0 left-0 translate-y-[unset] translate-x-[unset] border-[#BDFF00]"
               size="lg"
             />
           </div>

--- a/src/components/home/HomePromotedBets.tsx
+++ b/src/components/home/HomePromotedBets.tsx
@@ -47,40 +47,53 @@ export default function HomePromotedBets() {
   return (
     <>
       <div className="text-2xl font-bold pl-2">Featured Streams</div>
-      <Carousel className="flex-1 w-full">
-        <CarouselContent className="flex-1">
-          {isLoading ? (
-            <Skeleton className="flex-1 w-full h-64 rounded-none" />
-          ) : (
-            sortedData?.map((bet, i) => (
-              <CarouselItem key={i}>
-                <BetCard
-                  {...bet}
-                  setQuickPick={(streamId, roundId, streamName) => {
-                    setQuickPickModalSettings({
-                      streamId,
-                      streamName,
-                      roundId,
-                    });
-                    setQuickPickOpen(true);
-                  }}
-                />
-              </CarouselItem>
-            ))
-          )}
-        </CarouselContent>
-        <div className="flex items-center justify-between pt-4">
-          <CarouselPrevious
-            className="relative top-0 left-0 translate-y-[unset] translate-x-[unset]"
-            size="lg"
-          />
-          <CarouselDots className="relative" />
-          <CarouselNext
-            className="relative top-0 left-0 translate-y-[unset] translate-x-[unset]"
-            size="lg"
-          />
-        </div>
-      </Carousel>
+      <div className="rounded-lg p-6 -mx-4 bg-[radial-gradient(ellipse_at_center,_var(--tw-gradient-stops))] from-[#BDFF00]/20 via-zinc-900 via-40% to-background">
+        <Carousel 
+          className="flex-1 w-full"
+          opts={{
+          align: 'start',
+          loop: false,
+          slidesToScroll: 1,
+          containScroll: 'trimSnaps'
+        }}
+      >
+          <CarouselContent className="flex-1">
+            {isLoading ? (
+              <Skeleton className="flex-1 w-full h-64 rounded-none" />
+            ) : (
+              sortedData?.map((bet) => (
+                <CarouselItem 
+                  key={bet.roundId}
+                  className="basis-full md:basis-1/2 lg:basis-1/3 pl-4"
+                >
+                  <BetCard
+                    {...bet}
+                    setQuickPick={(streamId, roundId, streamName) => {
+                      setQuickPickModalSettings({
+                        streamId,
+                        streamName,
+                        roundId,
+                      });
+                      setQuickPickOpen(true);
+                    }}
+                  />
+                </CarouselItem>
+              ))
+            )}
+          </CarouselContent>
+          <div className="flex items-center justify-between pt-4">
+            <CarouselPrevious
+              className="relative top-0 left-0 translate-y-[unset] translate-x-[unset]"
+              size="lg"
+            />
+            <CarouselDots className="relative" />
+            <CarouselNext
+              className="relative top-0 left-0 translate-y-[unset] translate-x-[unset]"
+              size="lg"
+            />
+          </div>
+        </Carousel>
+      </div>
       {quickPickOpen && (
         <QuickPickModal
           open={quickPickOpen}


### PR DESCRIPTION
This pull request updates the `HomePromotedBets` component to improve its visual design and enhance the carousel experience for featured streams. The changes focus on styling, carousel configuration, and skeleton loading states.

**UI/UX Improvements:**

* Added a visually appealing background using a radial gradient and padding to the main container for featured streams, replacing the plain header. (`src/components/home/HomePromotedBets.tsx`)
* Updated carousel item layout and skeleton loading: skeletons now appear inside carousel items with rounded corners, and the carousel shows three skeletons while loading. (`src/components/home/HomePromotedBets.tsx`)
* Carousel items now use responsive widths (`basis-full`, `md:basis-1/2`, `lg:basis-1/3`) and padding for better layout across devices. (`src/components/home/HomePromotedBets.tsx`)

**Carousel Configuration:**

* Added custom carousel options for alignment, looping, and scroll behavior to improve usability and presentation. (`src/components/home/HomePromotedBets.tsx`)

**Component Styling:**

* Updated navigation button styles to include a custom border color (`#BDFF00`), enhancing visibility and matching the new design theme. (`src/components/home/HomePromotedBets.tsx`)