### PR TITLE
adds validation for auto-lock dates to make sure they're in the future

### DIFF
--- a/src/components/admin/AdminManagement.tsx
+++ b/src/components/admin/AdminManagement.tsx
@@ -15,7 +15,7 @@ import { formatDateTimeForISO, getImageLink, getMessage, isImageSFW, isScheduled
 import { validateStreamTitle, validateStreamDescription } from '@/utils/streamValidation';
 import { TabSwitch } from '../navigation/TabSwitch';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { BettingRounds, ValidationError } from './BettingRounds';
+import { BettingRounds, ValidationError, validateRounds } from './BettingRounds';
 import { AdminStreamContent } from './AdminStreamContent';
 import { BettingRoundStatus, CurrencyType, StreamStatus } from '@/enums';
 import { StreamInfoForm } from './StreamInfoForm';
@@ -672,6 +672,25 @@ export const AdminManagement = ({
         const el = document.querySelector('[data-round-index="' + errorIndices[0] + '"]');
         if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }, 500);
+      return;
+    }
+
+    // Validate for duplicate round/option names and auto-lock dates
+    const validationErrors = validateRounds(bettingRounds);
+    setBettingValidationErrors(validationErrors);
+    setShowBettingValidation(true);
+    if (validationErrors.length > 0) {
+      // Scroll to first validation error
+      setTimeout(() => {
+        const first = validationErrors[0];
+        const el = document.querySelector('[data-round-index="' + first.roundIndex + '"]');
+        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }, 500);
+      toast({
+        title: 'Validation Error',
+        description: validationErrors[0].message,
+        variant: 'destructive',
+      });
       return;
     }
 

--- a/src/components/creator/CreatorManagement.tsx
+++ b/src/components/creator/CreatorManagement.tsx
@@ -14,7 +14,7 @@ import { formatDateTimeForISO, getImageLink, getMessage, isImageSFW, isScheduled
 import { validateStreamTitle, validateStreamDescription } from '@/utils/streamValidation';
 import { TabSwitch } from '../navigation/TabSwitch';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { BettingRounds, ValidationError } from './BettingRounds';
+import { BettingRounds, ValidationError, validateRounds } from './BettingRounds';
 import { CreatorStreamContent } from './CreatorStreamContent';
 import { BettingRoundStatus, CurrencyType, StreamStatus } from '@/enums';
 import { StreamInfoForm } from './StreamInfoForm';
@@ -672,6 +672,25 @@ export const CreatorManagement = ({
         const el = document.querySelector('[data-round-index="' + errorIndices[0] + '"]');
         if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }, 500);
+      return;
+    }
+
+    // Validate for duplicate round/option names and auto-lock dates
+    const validationErrors = validateRounds(bettingRounds);
+    setBettingValidationErrors(validationErrors);
+    setShowBettingValidation(true);
+    if (validationErrors.length > 0) {
+      // Scroll to first validation error
+      setTimeout(() => {
+        const first = validationErrors[0];
+        const el = document.querySelector('[data-round-index="' + first.roundIndex + '"]');
+        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }, 500);
+      toast({
+        title: 'Validation Error',
+        description: validationErrors[0].message,
+        variant: 'destructive',
+      });
       return;
     }
 


### PR DESCRIPTION
This pull request introduces enhanced validation for betting rounds in both the admin and creator management components. The key improvement is the addition of a new `validateRounds` function, which checks for duplicate round or option names and auto-lock date issues before allowing submission. If validation fails, users are notified and scrolled to the relevant error.

**Betting round validation improvements:**

* Added `validateRounds` import and usage in both `AdminManagement` and `CreatorManagement` components to check for duplicate round/option names and auto-lock date issues before proceeding. [[1]](diffhunk://#diff-1234409323881471ea5909d87ddcadb28093fe3926259c851b0065d6ae20227eL18-R18) [[2]](diffhunk://#diff-6e8119a1b0dca99942a86afbc9a3b94dcff025a9abfad57c3f1be59d6a2a2bcbL17-R17)
* Implemented logic to display validation errors, show a toast notification with the first error, and automatically scroll to the problematic round for better user experience. [[1]](diffhunk://#diff-1234409323881471ea5909d87ddcadb28093fe3926259c851b0065d6ae20227eR678-R696) [[2]](diffhunk://#diff-6e8119a1b0dca99942a86afbc9a3b94dcff025a9abfad57c3f1be59d6a2a2bcbR678-R696)