### PR TITLE
refactor: simplify category selection in BettingRounds component

### DIFF
--- a/src/components/admin/BettingRounds.tsx
+++ b/src/components/admin/BettingRounds.tsx
@@ -448,12 +448,11 @@ export function BettingRounds({
                                 <label className="text-sm font-medium text-white mb-2 block">
                                   Category
                                 </label>
-                                <Select
-                                  value={round.category || BettingCategory.OTHER}
-                                  onValueChange={(value: BettingCategory) => updateCategory(roundIndex, value)}
-                                  disabled={isNotCreatedStatus}
-                                >
-                                  <SelectTrigger className="w-full bg-[#1a1a1a] border-[#2a2a2a] text-white">
+                              <Select
+                                value={round.category || BettingCategory.OTHER}
+                                onValueChange={(value: BettingCategory) => updateCategory(roundIndex, value)}
+                              >
+                                <SelectTrigger className="w-full bg-[#1a1a1a] border-[#2a2a2a] text-white">
                                     <SelectValue placeholder="Select a category" />
                                   </SelectTrigger>
                                   <SelectContent className="bg-[#1a1a1a] border-[#2a2a2a]">
@@ -702,6 +701,7 @@ export function BettingRounds({
                           <BetCardPreview
                             {...betCardInfo}
                             name={roundsState[roundIndex].roundName}
+                            category={roundsState[roundIndex].category || BettingCategory.OTHER}
                             options={roundsOptionsPreview[roundIndex]}
                             totalPot={{
                               streamCoins: 0,

--- a/src/components/creator/BettingRounds.tsx
+++ b/src/components/creator/BettingRounds.tsx
@@ -422,12 +422,11 @@ export function BettingRounds({
                               <label className="text-sm font-medium text-white mb-2 block">
                                 Category
                               </label>
-                              <Select
-                                value={round.category || BettingCategory.OTHER}
-                                onValueChange={(value: BettingCategory) => updateCategory(roundIndex, value)}
-                                disabled={isNotCreatedStatus}
-                              >
-                                <SelectTrigger className="w-full bg-[#1a1a1a] border-[#2a2a2a] text-white">
+                            <Select
+                              value={round.category || BettingCategory.OTHER}
+                              onValueChange={(value: BettingCategory) => updateCategory(roundIndex, value)}
+                            >
+                              <SelectTrigger className="w-full bg-[#1a1a1a] border-[#2a2a2a] text-white">
                                   <SelectValue placeholder="Select a category" />
                                 </SelectTrigger>
                                 <SelectContent className="bg-[#1a1a1a] border-[#2a2a2a]">
@@ -602,6 +601,7 @@ export function BettingRounds({
                         <BetCardPreview
                           {...betCardInfo}
                           name={roundsState[roundIndex].roundName}
+                          category={roundsState[roundIndex].category || BettingCategory.OTHER}
                           options={roundsOptionsPreview[roundIndex]}
                           totalPot={{
                             streamCoins: 0,


### PR DESCRIPTION
Goes with PR: https://github.com/Streambet-LLC/streambet_api/pull/112

This pull request makes minor updates to the betting round components for both admin and creator views. The main changes ensure that the `category` property is consistently passed to the `BetCardPreview` component and remove the unnecessary disabling of the category selection dropdown.

Betting round category handling:

* The `category` field is now always passed to the `BetCardPreview` component in both the admin (`src/components/admin/BettingRounds.tsx`) and creator (`src/components/creator/BettingRounds.tsx`) betting rounds components, defaulting to `BettingCategory.OTHER` if not set. [[1]](diffhunk://#diff-7dc968e8de79939ec6940ee82e4df56e3bd8fa86f0ef1f55a3425e213136baacR704) [[2]](diffhunk://#diff-732cb5bc328ac302feaff9512891d3a143981b07c33461cc863cafe87faf6b83R604)

UI consistency:

* The `disabled={isNotCreatedStatus}` prop has been removed from the category `Select` dropdown in both admin and creator betting rounds components, allowing category selection regardless of round status. [[1]](diffhunk://#diff-7dc968e8de79939ec6940ee82e4df56e3bd8fa86f0ef1f55a3425e213136baacL454) [[2]](diffhunk://#diff-732cb5bc328ac302feaff9512891d3a143981b07c33461cc863cafe87faf6b83L428)