### PR TITLE
hotfix: temporarily remove Emerging Sports category from UI

### DIFF
--- a/src/components/sidebar/SidebarBody.tsx
+++ b/src/components/sidebar/SidebarBody.tsx
@@ -55,7 +55,8 @@ export default function SidebarBody({ selectedCategory, setSelectedCategory }: S
       [BettingCategory.NEOSPORTS_ALTERNATIVE]: Goal,
       [BettingCategory.SPORTS]: Trophy,
       [BettingCategory.STREAMING_COMPETITIONS]: MonitorPlay,
-      [BettingCategory.EMERGING_SPORTS]: SwordsIcon,
+      // HOTFIX: Temporarily removed from UI - backend still supports this
+      // [BettingCategory.EMERGING_SPORTS]: SwordsIcon,
       [BettingCategory.OTHER]: MoreHorizontal,
     };
     return iconMap[category];

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -26,7 +26,8 @@ export enum BettingCategory {
   NEOSPORTS_ALTERNATIVE = 'neosports_alternative',
   SPORTS = 'sports',
   STREAMING_COMPETITIONS = 'streaming_competitions',
-  EMERGING_SPORTS = 'emerging_sports',
+  // HOTFIX: Temporarily removed from UI - backend still supports this
+  // EMERGING_SPORTS = 'emerging_sports',
   OTHER = 'other',
 }
 

--- a/src/utils/categoryHelpers.ts
+++ b/src/utils/categoryHelpers.ts
@@ -6,7 +6,8 @@ export const getCategoryLabel = (category: BettingCategory): string => {
     [BettingCategory.NEOSPORTS_ALTERNATIVE]: 'Alternative Sports',
     [BettingCategory.SPORTS]: 'Sports',
     [BettingCategory.STREAMING_COMPETITIONS]: 'Streaming Competitions',
-    [BettingCategory.EMERGING_SPORTS]: 'Emerging Sports',
+    // HOTFIX: Temporarily removed from UI - backend still supports this
+    // [BettingCategory.EMERGING_SPORTS]: 'Emerging Sports',
     [BettingCategory.OTHER]: 'Other',
   };
   return labels[category];


### PR DESCRIPTION
This pull request applies a hotfix to temporarily remove the "Emerging Sports" betting category from the UI, while keeping backend support intact. The changes ensure that "Emerging Sports" is not displayed or selectable in the sidebar, category labels, or category enumeration, but no backend logic is affected.

**UI removal of "Emerging Sports" category:**

* Commented out the `EMERGING_SPORTS` entry in the `BettingCategory` enum to prevent its use in the UI.
* Commented out the "Emerging Sports" label mapping in `getCategoryLabel` so it won't be shown in category labels.
* Commented out the "Emerging Sports" icon mapping in the sidebar, so the category and its icon are not rendered in the sidebar UI.