### PR TITLE
fix: adjust BetCard and FeaturedBetCard styles for improved layout and responsiveness

### DIFF
--- a/src/components/BetCard.tsx
+++ b/src/components/BetCard.tsx
@@ -130,7 +130,7 @@ export default function BetCard(props: BetCardType) {
           'h-full flex flex-col overflow-hidden transition-all duration-200 rounded-xl',
           wiggle && 'wiggle',
           !props.isFeatured && 'relative bg-card-grid-bg border border-card-grid-border shadow-[0px_2px_8px_0px_rgba(0,0,0,0.5)] hover:border-card-grid-border-hover hover:shadow-[0px_4px_16px_0px_rgba(189,255,0,0.1)]',
-          props.isFeatured && 'bg-transparent border-0 shadow-none'
+          props.isFeatured && 'bg-transparent border-0 shadow-none min-h-[420px]'
         )}
       >
       <CardHeader className="p-4 pb-0 flex flex-col gap-3">
@@ -239,7 +239,7 @@ export default function BetCard(props: BetCardType) {
           )}
         </div>
       </CardHeader>
-      <CardContent className="flex-1 flex flex-col gap-2 p-4">
+      <CardContent className="flex flex-col gap-2 p-4">
         <div className="flex flex-col">
           {props.type === 'stream' && (
             <Link
@@ -272,7 +272,7 @@ export default function BetCard(props: BetCardType) {
                 : undefined
             }
             className={cn(
-              'flex-1 flex gap-4 items-center justify-between transition-all px-3 py-1 rounded-md border bg-bet-option-bg border-bet-option-border',
+              'flex gap-4 items-center justify-between transition-all px-3 py-1 rounded-md border bg-bet-option-bg border-bet-option-border',
               statuses.canOpen
                 ? 'hover:text-electric-lime hover:shadow-[0_0_20px_rgba(189,255,0,0.4)] cursor-pointer'
                 : 'cursor-not-allowed opacity-60',
@@ -309,7 +309,7 @@ export default function BetCard(props: BetCardType) {
                 : undefined
             }
             className={cn(
-              'flex-1 flex gap-4 items-center justify-between transition-all px-3 py-2.5 rounded-md border bg-bet-option-bg border-bet-option-border',
+              'flex gap-4 items-center justify-between transition-all px-3 py-2.5 rounded-md border bg-bet-option-bg border-bet-option-border',
               statuses.canOpen
                 ? 'hover:text-electric-lime hover:shadow-[0_0_20px_rgba(189,255,0,0.4)] cursor-pointer'
                 : 'cursor-not-allowed opacity-60'
@@ -321,9 +321,8 @@ export default function BetCard(props: BetCardType) {
           </div>
         )}
       </CardContent>
-      <CardFooter className="mt-auto"></CardFooter>
-      <div className="p-6 pt-0">
-        <div className="flex flex-wrap items-start justify-between gap-2">
+      <CardFooter className="mt-auto p-6 pt-0">
+        <div className="flex flex-wrap items-start justify-between gap-2 w-full">
           <Tooltip delayDuration={0}>
             <TooltipTrigger asChild>
               <div className="flex gap-2 items-center text-gray-400 cursor-pointer">
@@ -346,7 +345,7 @@ export default function BetCard(props: BetCardType) {
             />
           )}
         </div>
-      </div>
+      </CardFooter>
     </CardWrapper>
     </motion.div>
   );

--- a/src/components/FeaturedBetCard.tsx
+++ b/src/components/FeaturedBetCard.tsx
@@ -25,7 +25,7 @@ export default function FeaturedBetCard({ children, className }: FeaturedBetCard
         className="absolute inset-0 pointer-events-none rounded-featured-card shadow-neon-glow"
       />
       {/* Content wrapper */}
-      <div className="relative h-full flex flex-col">{children}</div>
+      <div className="relative flex flex-col flex-1">{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
This pull request refactors the layout and styling of the `BetCard` and `FeaturedBetCard` components to improve their flexibility and visual consistency. The main changes focus on the card structure, content alignment, and responsive sizing, especially for featured cards.

**Layout and Structure Improvements:**

* Ensured featured bet cards have a minimum height by adding `min-h-[420px]` to their container, improving visual consistency for featured items.
* Updated the content wrapper in `FeaturedBetCard` to use `flex-1`, making its content fill available space more reliably.

**Styling and Alignment Adjustments:**

* Removed the `flex-1` class from several flex containers within bet option elements to prevent unintended stretching and maintain proper alignment. [[1]](diffhunk://#diff-4b2fa285a7aa410025e2e18be6aad42f28ce32fe5e2c9d281d0dbd73ce23b651L275-R275) [[2]](diffhunk://#diff-4b2fa285a7aa410025e2e18be6aad42f28ce32fe5e2c9d281d0dbd73ce23b651L312-R312)
* Modified the layout of `CardContent` by removing the `flex-1` class, preventing the content from forcibly stretching and allowing for more natural sizing.

**Footer Consolidation:**

* Moved the footer content directly into the `CardFooter` element, added padding and full-width styling, and removed the redundant outer `div` for cleaner markup and better alignment. [[1]](diffhunk://#diff-4b2fa285a7aa410025e2e18be6aad42f28ce32fe5e2c9d281d0dbd73ce23b651L324-R325) [[2]](diffhunk://#diff-4b2fa285a7aa410025e2e18be6aad42f28ce32fe5e2c9d281d0dbd73ce23b651L349-R348)