### PR TITLE
fix: update UI components for improved accessibility and consistency

### DIFF
--- a/src/components/BetCard.tsx
+++ b/src/components/BetCard.tsx
@@ -341,7 +341,14 @@ export default function BetCard(props: BetCardType) {
           {cardData.lockDate && (
             <StreamStatusBadge 
               status="lock" 
-              lockDate={moment(cardData.lockDate).format('MMM D, YYYY [at] h:mm A')}
+              lockDate={(() => {
+                const date = new Date(cardData.lockDate);
+                const formattedDate = moment(cardData.lockDate).format('MMM D, YYYY [at] h:mm A');
+                const timezone = date.toLocaleTimeString('en-US', { 
+                  timeZoneName: 'short' 
+                }).split(' ').pop();
+                return `${formattedDate} ${timezone}`;
+              })()}
             />
           )}
         </div>

--- a/src/components/FeaturedBetCard.tsx
+++ b/src/components/FeaturedBetCard.tsx
@@ -10,14 +10,15 @@ export default function FeaturedBetCard({ children, className }: FeaturedBetCard
   return (
     <div
       className={cn(
-        'relative rounded-featured-card overflow-hidden bg-featured-gradient h-full flex flex-col',
+        'relative rounded-featured-card overflow-hidden h-full flex flex-col',
         className
       )}
+      style={{ backgroundColor: 'var(--card-grid-bg)' }}
     >
       {/* Border overlay */}
       <div
         aria-hidden="true"
-        className="absolute border border-featured-card-border inset-0 pointer-events-none rounded-featured-card"
+        className="absolute border border-card-grid-border inset-0 pointer-events-none rounded-featured-card"
       />
       {/* Shadow overlay */}
       <div 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -86,9 +86,9 @@ export const Navigation = ({ onDashboardClick, searchValue, onSearchChange }: Na
   };
 
   const menuItems = [
-    (session?.role === 'admin' || session?.role === 'creator') && { label: 'Dashboard', icon: undefined, path: session?.role === 'admin' ? '/admin' : '/creator' },
     { label: 'Home', icon: undefined, path: '/' },
-    { label: 'Creators', icon: undefined, path: '/creators' },
+    { label: 'Browse', icon: undefined, path: '/creators' },
+    (session?.role === 'admin' || session?.role === 'creator') && { label: 'Creator Dashboard', icon: undefined, path: session?.role === 'admin' ? '/admin' : '/creator' },
     // { label: 'Streams', icon: undefined, path: '/stream' },
     // { label: 'Rewards', icon: undefined, path: '/rewards' },
     // { label: 'Community', icon: undefined, path: '/community' },
@@ -242,13 +242,14 @@ export const Navigation = ({ onDashboardClick, searchValue, onSearchChange }: Na
           {/* Center Column: Search Bar - Only on Homepage */}
           <div className="hidden md:flex flex-1 justify-center mx-4">
             {isHomePage && searchValue !== undefined && onSearchChange && (
-              <div className="max-w-[200px] md:max-w-md w-full">
+              <div className="max-w-[280px] md:max-w-lg w-full">
                 <SearchInput
                   id="nav-search"
                   value={searchValue}
                   onChange={onSearchChange}
                   width="full"
-                  className="border-none"
+                  placeholder="Search Picks, creators, streams..."
+                  className="border-primary/60 shadow-[0_0_8px_rgba(189,255,0,0.3)]"
                 />
               </div>
             )}

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -41,6 +41,8 @@ export default function Home() {
             value={searchValue}
             onChange={setSearchValue}
             width="full"
+            placeholder="Search Picks, creators, streams..."
+            className="border-primary/60 shadow-[0_0_8px_rgba(189,255,0,0.3)]"
           />
         </div>
 

--- a/src/components/home/HomeBets.tsx
+++ b/src/components/home/HomeBets.tsx
@@ -85,6 +85,7 @@ export default function HomeBets({ filters, selectedCategory, setSelectedCategor
 
   return (
     <>
+      <h2 className="text-2xl font-bold mb-4 px-2">All Picks:</h2>
       <div className="flex flex-col gap-4">
         {/* Category Tabs */}
         <div 

--- a/src/components/home/HomePromotedBets.tsx
+++ b/src/components/home/HomePromotedBets.tsx
@@ -47,6 +47,7 @@ export default function HomePromotedBets() {
 
   return (
     <>
+      <h2 className="text-2xl font-bold  px-2">Featured Picks:</h2>
       <div className="p-6 -mx-4">
         <Carousel
           className="flex-1 w-full"

--- a/src/components/navigation/UserDropdown.tsx
+++ b/src/components/navigation/UserDropdown.tsx
@@ -107,7 +107,11 @@ export const UserDropdown = ({ profile, onLogout }: UserDropdownProps) => {
         </DropdownMenuItem>
 
         <DropdownMenuItem asChild className="cursor-pointer">
-          <Link to="/betting-history">Pick history</Link>
+          <Link to="/betting-history">Pick History</Link>
+        </DropdownMenuItem>
+
+        <DropdownMenuItem asChild className="cursor-pointer">
+          <Link to="/transactions">Transaction History</Link>
         </DropdownMenuItem>
 
         <DropdownMenuItem asChild className="cursor-pointer">
@@ -115,14 +119,10 @@ export const UserDropdown = ({ profile, onLogout }: UserDropdownProps) => {
         </DropdownMenuItem>
 
         <DropdownMenuItem asChild className="cursor-pointer">
-          <Link to="/transactions">Transaction history</Link>
-        </DropdownMenuItem>
-
-        <DropdownMenuItem asChild className="cursor-pointer">
           <Link to="/settings">Settings</Link>
         </DropdownMenuItem>
 
-        <DropdownMenuItem onClick={() => onLogout()} className="cursor-pointer">Log out</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => onLogout()} className="cursor-pointer">Log Out</DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/ui/SearchInput.tsx
+++ b/src/components/ui/SearchInput.tsx
@@ -70,7 +70,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
         onChange={(e) => onChange(e.target.value)}
         disabled={disabled}
         autoFocus={autoFocus}
-        className={cn('pl-9 rounded-md', value.length > 0 && 'pr-9')}
+        className={cn('pl-9 rounded-md text-base placeholder:text-muted-foreground bg-card-grid-bg shadow-input-glow', value.length > 0 && 'pr-9')}
         aria-label={placeholder}
 		    inputMode="search"
       />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -103,6 +103,7 @@ export default {
       },
       boxShadow: {
         'neon-glow': `0px 1px 0px 0px inset rgba(189,255,0,0.2), 0px -1px 0px 0px inset rgba(255,255,255,0.24), 0px -20px 50px 0px inset rgba(189,255,0,0.13), 0px -3px 30px 0px inset rgba(189,255,0,0.33), 0px 0px 60px 0px rgba(189,255,0,0.15)`,
+        'input-glow': '0px 1px 0px 0px inset rgba(189,255,0,0.15), 0px -1px 0px 0px inset rgba(255,255,255,0.1), 0px -10px 30px 0px inset rgba(189,255,0,0.08)',
         'card-subtle': '0px 1px 0px 0px inset rgba(189,255,0,0.1), 0px -1px 0px 0px inset rgba(255,255,255,0.08), 0px 4px 12px 0px rgba(0,0,0,0.6)',
         'card-subtle-hover': '0px 1px 0px 0px inset rgba(189,255,0,0.15), 0px -1px 0px 0px inset rgba(255,255,255,0.12), 0px 6px 20px 0px rgba(189,255,0,0.12), 0px 2px 8px 0px rgba(0,0,0,0.7)',
       },


### PR DESCRIPTION
This pull request introduces several UI and UX improvements across navigation, cards, and search components, with a focus on visual consistency, improved terminology, and enhanced user experience. The most important changes are grouped below by theme.

**Navigation and Terminology Updates:**

* The navigation menu was updated to rename "Creators" to "Browse" and "Dashboard" to "Creator Dashboard," clarifying user roles and improving discoverability. The search bar on the homepage was widened and now features a more prominent style and placeholder for better usability. [[1]](diffhunk://#diff-0a53ec42b8db78013ad213a9f952a9b25ef65c0ce9ee169bd1b65af00f245607L89-R91) [[2]](diffhunk://#diff-0a53ec42b8db78013ad213a9f952a9b25ef65c0ce9ee169bd1b65af00f245607L245-R252)
* The user dropdown menu was reorganized: "Pick history" is now "Pick History," "Transaction history" is now "Transaction History," and "Redeem Stream Coins" and "Transaction History" swapped order for logical grouping. The logout button label was changed to "Log Out" for consistency.

**Visual and Styling Enhancements:**

* The `FeaturedBetCard` background and border classes were updated for improved styling consistency, now using CSS variables and new border tokens.
* The `SearchInput` component and homepage search bar received updated styles, including a new glow effect and improved placeholder text for a more modern, visually appealing look. [[1]](diffhunk://#diff-5176876c38023dfb87fab4f0efe4c7fbf3d39dc75d0dc7db3f2a86f19d83e1c3L73-R73) [[2]](diffhunk://#diff-62319f77d45e2a111f122311d1cfb1a08287144b70557fff36a9674da39773d6R44-R45)
* Added new Tailwind box shadow utility `input-glow` to support the improved input field appearance.

**Content and Labeling Improvements:**

* Added section headings "All Picks:" and "Featured Picks:" above bet lists and carousels on the homepage for better content clarity. [[1]](diffhunk://#diff-e129d1cf5ef3e7db708e0368e7b2c32d99043b7edeaa610b0b1087b8a1bde027R88) [[2]](diffhunk://#diff-1e5da1120b2c815d06d24f57742c5cc1195bb1611eb019041870d662361728eeR50)

**Date and Time Display:**

* The `BetCard` lock date now displays the local timezone abbreviation alongside the formatted date, improving clarity for users in different regions.