### PR TITLE
fix: remove decimals from leaderboard totals and hide categories

### DIFF
--- a/src/components/leaderboard/LeaderboardTable.tsx
+++ b/src/components/leaderboard/LeaderboardTable.tsx
@@ -83,8 +83,8 @@ export const LeaderboardTable = () => {
     if (data && data.length > 0) {
       const total = data.reduce((sum, entry) => sum + Number(entry.goldCoins), 0);
       const lead = data.length > 1 ? Number(data[0].goldCoins) - Number(data[1].goldCoins) : 0;
-      setTotalGold(total);
-      setTopLead(lead);
+      setTotalGold(Math.floor(total));
+      setTopLead(Math.floor(lead));
     }
   }, [data]);
 
@@ -147,7 +147,7 @@ export const LeaderboardTable = () => {
               Total <span style={{ color: 'var(--gold-coin)' }}>Cade Coins</span>
             </div>
             <div className="text-base md:text-xl font-mono font-bold crt-glow-medium" style={{ color: 'var(--electric-lime)' }}>
-              {animatedTotal.toLocaleString()}
+              {Math.floor(animatedTotal).toLocaleString()}
             </div>
           </div>
 
@@ -166,7 +166,7 @@ export const LeaderboardTable = () => {
               Top Lead
             </div>
             <div className="text-base md:text-xl font-mono font-bold crt-glow-medium" style={{ color: 'var(--electric-lime)' }}>
-              {animatedLead.toLocaleString()}
+              {Math.floor(animatedLead).toLocaleString()}
             </div>
           </div>
         </div>
@@ -227,7 +227,7 @@ export const LeaderboardTable = () => {
                 className={`text-sm md:text-xl font-mono font-bold crt-glow-medium ${index < 3 ? '' : 'text-white/75'}`}
                 style={{ color: index < 3 ? 'var(--electric-lime)' : undefined }}
               >
-                {Number(entry.goldCoins).toLocaleString()}
+                {Math.floor(Number(entry.goldCoins)).toLocaleString()}
               </div>
               <div className="text-[10px] md:text-xs uppercase tracking-wide crt-glow-medium" style={{ color: 'var(--gold-coin)' }}>
                 Cade Coins

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -25,8 +25,8 @@ export enum BettingCategory {
   TRADING_CARDS = 'trading_cards',
   NEOSPORTS_ALTERNATIVE = 'neosports_alternative',
   SPORTS = 'sports',
-  STREAMING_COMPETITIONS = 'streaming_competitions',
   // HOTFIX: Temporarily removed from UI - backend still supports this
+  // STREAMING_COMPETITIONS = 'streaming_competitions',
   // EMERGING_SPORTS = 'emerging_sports',
   OTHER = 'other',
 }


### PR DESCRIPTION
This pull request makes improvements to the leaderboard display logic and updates the betting category enumeration. The main focus is on ensuring that coin values are consistently rounded down to whole numbers before display, which improves accuracy and visual consistency. Additionally, a betting category is commented out for UI purposes.

**Leaderboard display improvements:**

* All coin-related values (`totalGold`, `topLead`, and individual `goldCoins`) are now rounded down to the nearest integer using `Math.floor` before being set or displayed, ensuring that only whole numbers are shown. [[1]](diffhunk://#diff-2eee82dd64917c549bbbf9b5d8df65de34ae58e9921f6ae20eb729a19be73c04L86-R87) [[2]](diffhunk://#diff-2eee82dd64917c549bbbf9b5d8df65de34ae58e9921f6ae20eb729a19be73c04L150-R150) [[3]](diffhunk://#diff-2eee82dd64917c549bbbf9b5d8df65de34ae58e9921f6ae20eb729a19be73c04L169-R169) [[4]](diffhunk://#diff-2eee82dd64917c549bbbf9b5d8df65de34ae58e9921f6ae20eb729a19be73c04L230-R230)

**Betting category enumeration update:**

* The `STREAMING_COMPETITIONS` category in the `BettingCategory` enum is now commented out, temporarily removing it from the UI while keeping backend support.