### PR TITLE
Add user role management: implement creator status toggle in UserTable

### DIFF
--- a/src/components/admin/UserTable.tsx
+++ b/src/components/admin/UserTable.tsx
@@ -20,6 +20,7 @@ import { Badge } from '@/components/ui/badge';
 import api from '@/integrations/api/client';
 import { cn } from '@/lib/utils';
 import { Switch } from '@/components/ui/switch';
+import { Checkbox } from '@/components/ui/checkbox';
 import { DeleteUserDialog } from './DeleteUserDialog';
 import AddTokens from './AddTokens';
 import { useToast } from '@/hooks/use-toast';
@@ -75,6 +76,27 @@ export const UserTable: React.FC<Props> = ({ searchUserQuery }) => {
     onSuccess: () => {
       refetchProfiles();
       refetchSession();
+    },
+  });
+
+  const updateCreatorStatusMutation = useMutation({
+    mutationFn: async ({ userId, isCreator }: { userId: string; isCreator: boolean }) => {
+      return await api.admin.updateUserCreatorStatus({ userId, isCreator });
+    },
+    onSuccess: () => {
+      refetchProfiles();
+      toast({
+        description: 'User role updated successfully',
+        variant: 'default',
+      });
+    },
+    onError: (error: any) => {
+      toast({
+        title: 'Error',
+        description: error?.response?.data?.message || 'Failed to update user role',
+        variant: 'destructive',
+      });
+      refetchProfiles();
     },
   });
 
@@ -195,6 +217,21 @@ export const UserTable: React.FC<Props> = ({ searchUserQuery }) => {
                     </span>
                   </div>
 
+                  {/* Creator */}
+                  <div className="flex justify-between items-center">
+                    <span className="text-sm text-muted-foreground">Creator:</span>
+                    <Checkbox
+                      checked={user?.role === 'creator'}
+                      disabled={user?.role === 'admin'}
+                      onCheckedChange={() => {
+                        updateCreatorStatusMutation.mutate({
+                          userId: user.id,
+                          isCreator: user?.role !== 'creator',
+                        });
+                      }}
+                    />
+                  </div>
+
                   {/* Actions Row */}
                   <div className="flex justify-between items-center pt-2 border-t border-gray-800">
                     <AddTokens
@@ -233,6 +270,7 @@ export const UserTable: React.FC<Props> = ({ searchUserQuery }) => {
                 <TableHead>Actions</TableHead>
                 <TableHead>Gold Coins</TableHead>
                 <TableHead>Edit</TableHead>
+                <TableHead>Creator</TableHead>
                 <TableHead>Delete</TableHead>
               </TableRow>
             </TableHeader>
@@ -318,6 +356,18 @@ export const UserTable: React.FC<Props> = ({ searchUserQuery }) => {
                     </TableCell>
                     <TableCell className="cursor-pointer" title="Edit">
                       <EditUserDialog profile={user} onUpdate={handleEditUser} />
+                    </TableCell>
+                    <TableCell className="cursor-pointer" title="Toggle Creator Role">
+                      <Checkbox
+                        checked={user?.role === 'creator'}
+                        disabled={user?.role === 'admin'}
+                        onCheckedChange={() => {
+                          updateCreatorStatusMutation.mutate({
+                            userId: user.id,
+                            isCreator: user?.role !== 'creator',
+                          });
+                        }}
+                      />
                     </TableCell>
                     <TableCell className="cursor-pointer" title="Delete">
                       <DeleteUserDialog

--- a/src/integrations/api/client.ts
+++ b/src/integrations/api/client.ts
@@ -728,6 +728,11 @@ export const adminAPI = {
     return response.data;
   },
 
+  updateUserCreatorStatus: async (payload: { userId: string; isCreator: boolean }) => {
+    const response = await apiClient.patch(`/admin/users/creator-role`, payload);
+    return response.data;
+  },
+
   updateUserCoins: async (payload: { userId: string; amount: number }) => {
     const response = await apiClient.patch(`/admin/gold-coins`, payload);
     return response.data;


### PR DESCRIPTION
Note: This goes with PR https://github.com/Streambet-LLC/streambet_api/pull/158

This pull request adds the ability for admins to view and update a user's "creator" role directly from the user table in the admin panel. The main changes include UI updates to display and toggle the creator status, as well as API integration to persist these changes.

**User Role Management Enhancements:**

* Added a new `Checkbox` component to the user table UI, allowing admins to toggle the "creator" role for each user (disabled for admins). The creator status can be updated both from the user's detail row and directly in the table. [[1]](diffhunk://#diff-4659b266240d09033bccef9e3d7c354fad07279f7d8d33fe20ebd02bfb151a8eR220-R234) [[2]](diffhunk://#diff-4659b266240d09033bccef9e3d7c354fad07279f7d8d33fe20ebd02bfb151a8eR360-R371) [[3]](diffhunk://#diff-4659b266240d09033bccef9e3d7c354fad07279f7d8d33fe20ebd02bfb151a8eR273) [[4]](diffhunk://#diff-4659b266240d09033bccef9e3d7c354fad07279f7d8d33fe20ebd02bfb151a8eR23)
* Introduced a new mutation using `useMutation` to handle creator role updates, with success and error toast notifications and automatic table refresh.

**API Integration:**

* Added a new API client method `updateUserCreatorStatus` that sends a PATCH request to `/admin/users/creator-role` to update the user's creator status.