### PR TITLE
Update PromoCard component styles for improved border visibility

### DIFF
--- a/src/components/home/PromoCard.tsx
+++ b/src/components/home/PromoCard.tsx
@@ -41,7 +41,7 @@ export default function PromoCard({
 
   return (
     <Card className={cn(
-      "w-full overflow-hidden bg-card-grid-bg border border-card-grid-border",
+      "w-full overflow-hidden bg-card-grid-bg border-2 border-primary/50",
       className
     )}>
       <div className="relative w-full aspect-[21/9] overflow-hidden" style={{ maxHeight: '300px' }}>


### PR DESCRIPTION
This pull request makes a small UI update to the `PromoCard` component. The change updates the card's border style to use a thicker border and a primary color with partial opacity. 

- Changed the `PromoCard` border from a standard border to a `border-2` with `border-primary/50` for improved visual emphasis (`src/components/home/PromoCard.tsx`).