### PR TITLE
update PromoCard styling: change border to border-2 and update color to border-primary/50

### DIFF
--- a/src/components/home/PromoCard.tsx
+++ b/src/components/home/PromoCard.tsx
@@ -41,7 +41,7 @@ export default function PromoCard({
 
   return (
     <Card className={cn(
-      "w-full overflow-hidden bg-card-grid-bg border border-card-grid-border",
+      "w-full overflow-hidden bg-card-grid-bg border-2 border-primary/50",
       className
     )}>
       <div className="relative w-full aspect-[21/9] overflow-hidden" style={{ maxHeight: '300px' }}>


### PR DESCRIPTION
This pull request makes a small visual update to the `PromoCard` component by changing its border styling to use a thicker, semi-transparent primary color border instead of the previous card grid border.

- Updated the `PromoCard` component's border to use `border-2 border-primary/50` for a more prominent and branded appearance, replacing the previous `border border-card-grid-border` style.