### PR TITLE
refactor: simplify BettingRounds and InlineEditable components, remove unused dialog logic

### DIFF
--- a/src/components/admin/BettingRounds.tsx
+++ b/src/components/admin/BettingRounds.tsx
@@ -12,18 +12,9 @@ import { DeleteBettingDialog } from './DeleteBettingDialog';
 import { InlineEditable } from './InlineEditable';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { Edit, Copy } from 'lucide-react';
-import { BettingRoundStatus, BettingCategory } from '@/enums';
+import { BettingRoundStatus, BettingCategory, CurrencyType } from '@/enums';
 import { toast } from '@/components/ui/use-toast';
 import { getCategoryLabel } from '@/utils/categoryHelpers';
-import {
-  AlertDialog,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogCancel,
-} from '@/components/ui/alert-dialog';
 import {
   TEMP_OPTION_PREFIX,
   cleanTemporaryIds,
@@ -91,7 +82,6 @@ export function BettingRounds({
 }: BettingRoundsProps) {
   const isMobile = useIsMobile();
   const [expandedRounds, setExpandedRounds] = useState<string[]>([]);
-  const [alertDialogIndex, setAlertDialogIndex] = useState<number | null>(null);
   const roundRefs = useRef<(HTMLDivElement | null)[]>([]);
   const roundsListRef = useRef<HTMLDivElement | null>(null);
   const prevRoundsLength = useRef<number>(rounds.length);
@@ -106,9 +96,14 @@ export function BettingRounds({
   const roundsOptionsPreview = useMemo(() => {
     return roundsState.map(round =>
       round.options.map(option => ({
+        id: option.optionId || '',
         option: option.option,
         percentage: 100,
         isWinner: false,
+        userBet: {
+          amount: 0,
+          currency: CurrencyType.STREAM_COINS,
+        },
       }))
     );
   }, [roundsState]);
@@ -362,7 +357,6 @@ export function BettingRounds({
                                 <InlineEditable
                                   title="Edit Round Name"
                                   value={round.roundName}
-                                  isNotCreatedStatus={isNotCreatedStatus}
                                   onSave={newName => updateRoundName(roundIndex, newName)}
                                   className={`text-white font-medium ${hasRoundError ? 'text-destructive' : ''}`}
                                   style={{
@@ -372,7 +366,6 @@ export function BettingRounds({
                                     minWidth: 0,
                                   }}
                                   minLength={2}
-                                  createdAt={round.createdAt}
                                 />
                               </div>
                               <div className="flex items-center gap-2 flex-wrap">
@@ -381,40 +374,10 @@ export function BettingRounds({
                                   className="bg-[#272727] text-white font-medium px-3 rounded-lg border-none text-sm flex items-center justify-center hover:bg-[#232323] focus:bg-[#232323] active:bg-[#1a1a1a] transition-colors"
                                   style={{ height: 33, fontSize: '16px', fontWeight: 500 }}
                                   disabled={isSaving}
-                                  onClick={() => {
-                                    if (isNotCreatedStatus) {
-                                      setAlertDialogIndex(roundIndex);
-                                    } else {
-                                      addNewOption(roundIndex);
-                                    }
-                                  }}
+                                  onClick={() => addNewOption(roundIndex)}
                                 >
                                   + New option
                                 </Button>
-                                {alertDialogIndex === roundIndex && (
-                                  <AlertDialog
-                                    open={true}
-                                    onOpenChange={open => {
-                                      if (!open) setAlertDialogIndex(null);
-                                    }}
-                                  >
-                                    <AlertDialogContent className="border border-primary">
-                                      <AlertDialogHeader>
-                                        <AlertDialogTitle>Cannot add new option</AlertDialogTitle>
-                                        <AlertDialogDescription>
-                                          This round is already started by admin.
-                                        </AlertDialogDescription>
-                                      </AlertDialogHeader>
-                                      <AlertDialogFooter>
-                                        <AlertDialogCancel
-                                          onClick={() => setAlertDialogIndex(null)}
-                                        >
-                                          Cancel
-                                        </AlertDialogCancel>
-                                      </AlertDialogFooter>
-                                    </AlertDialogContent>
-                                  </AlertDialog>
-                                )}
                                 <Button
                                   type="button"
                                   className="bg-[#272727] text-white font-medium px-3 rounded-lg border-none text-sm flex items-center justify-center hover:bg-[#232323] focus:bg-[#232323] active:bg-[#1a1a1a] transition-colors"
@@ -627,7 +590,6 @@ export function BettingRounds({
                                       >
                                         <InlineEditable
                                           title="Edit Option Name"
-                                          isNotCreatedStatus={isNotCreatedStatus}
                                           value={option.option}
                                           onSave={newName =>
                                             updateOptionName(roundIndex, optionIndex, newName)

--- a/src/components/admin/DeleteBettingDialog.tsx
+++ b/src/components/admin/DeleteBettingDialog.tsx
@@ -17,22 +17,24 @@ interface DeleteBettingDialogProps {
   title: string;
   trigger?: React.ReactNode;
   isNotCreatedStatus?: boolean;
+  isLocked?: boolean;
 }
 
-export function DeleteBettingDialog({ onConfirm, message, title, trigger, isNotCreatedStatus }: DeleteBettingDialogProps) {
+export function DeleteBettingDialog({ onConfirm, message, title, trigger, isNotCreatedStatus, isLocked }: DeleteBettingDialogProps) {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
   const handleDeleteClick = () => {
-    if (isNotCreatedStatus) {
-      // Show error message instead of delete dialog
-      setIsDeleteDialogOpen(true);
-    } else {
-      // Show normal delete confirmation
-      setIsDeleteDialogOpen(true);
-    }
+    setIsDeleteDialogOpen(true);
   };
 
   const getDialogContent = () => {
+    if (isLocked) {
+      return {
+        title: "Cannot Delete",
+        message: "Cannot delete this option as the round is locked",
+        showConfirmButton: false
+      };
+    }
     if (isNotCreatedStatus) {
       return {
         title: "Cannot Delete",

--- a/src/components/admin/InlineEditable.tsx
+++ b/src/components/admin/InlineEditable.tsx
@@ -10,7 +10,6 @@ import {
 } from '@/components/ui/dialog';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Edit } from 'lucide-react';
-import moment from 'moment';
 
 interface InlineEditableProps {
   value: string;
@@ -19,9 +18,7 @@ interface InlineEditableProps {
   minLength?: number;
   placeholder?: string;
   style?: React.CSSProperties;
-  isNotCreatedStatus?: boolean;
   title?: string;
-  createdAt?: string;
 }
 
 export function InlineEditable({
@@ -30,21 +27,15 @@ export function InlineEditable({
   className = '',
   minLength = 3,
   placeholder = 'Enter text...',
-  isNotCreatedStatus,
   style,
   title,
-  createdAt = null,
 }: InlineEditableProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(value);
   const [error, setError] = useState('');
-  const [showNotEditableDialog, setShowNotEditableDialog] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const editableRef = useRef<HTMLSpanElement>(null); // Reintroduce a ref for the editable span
-  const [errorMessage, setErrorMessage] = useState(
-    'Cannot edit this field as this round already started by admin'
-  );
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -53,23 +44,6 @@ export function InlineEditable({
   }, [isEditing]);
 
   const handleClick = () => {
-    if (createdAt) {
-      console.log('asdfasdf');
-
-      if (moment(createdAt).isBefore(moment().subtract(1, 'hours'))) {
-        setErrorMessage(
-          'Cannot edit this field as this its been more than 1 hour since its created'
-        );
-        setShowNotEditableDialog(true);
-        return;
-      }
-    } else {
-      if (isNotCreatedStatus) {
-        setErrorMessage('Cannot edit this field as this round already started by admin');
-        setShowNotEditableDialog(true);
-        return;
-      }
-    }
     setIsEditing(true);
     setEditValue(value);
     setError('');
@@ -109,7 +83,7 @@ export function InlineEditable({
   return (
     <>
       <TooltipProvider>
-        <Tooltip open={!isEditing && !showNotEditableDialog && isHovering}>
+        <Tooltip open={!isEditing && isHovering}>
           <TooltipTrigger asChild>
             <span
               ref={editableRef} // Assign the editableRef to the span
@@ -165,22 +139,6 @@ export function InlineEditable({
             >
               Save
             </button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={showNotEditableDialog} onOpenChange={setShowNotEditableDialog}>
-        <DialogContent className="border-2 border-[#7AFF14]" style={{ background: '#0D0D0D' }}>
-          <DialogHeader>
-            <DialogTitle>Cannot Edit</DialogTitle>
-          </DialogHeader>
-          <div className="py-2 text-sm">{errorMessage}</div>
-          <DialogFooter>
-            <DialogClose asChild>
-              <button className="bg-[#272727] text-white font-medium px-3 rounded-lg border-none text-sm flex items-center justify-center hover:bg-[#232323] focus:bg-[#232323] active:bg-[#1a1a1a] transition-colors h-10">
-                Close
-              </button>
-            </DialogClose>
           </DialogFooter>
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
This pull request simplifies the logic for editing and adding betting round options in the admin panel by removing restrictions and related UI for rounds that have already started or are locked. It also introduces a new `isLocked` prop to the `DeleteBettingDialog` for more granular control over deletion permissions and cleans up unused props and code in the `InlineEditable` component.

**Admin Betting Rounds Simplification:**
- Removed logic and UI that prevented editing or adding options to rounds that have already started, including the associated alert dialog and props like `isNotCreatedStatus` and `createdAt` from `InlineEditable` and related usage in `BettingRounds.tsx`. [[1]](diffhunk://#diff-7dc968e8de79939ec6940ee82e4df56e3bd8fa86f0ef1f55a3425e213136baacL15-L26) [[2]](diffhunk://#diff-7dc968e8de79939ec6940ee82e4df56e3bd8fa86f0ef1f55a3425e213136baacL365) [[3]](diffhunk://#diff-7dc968e8de79939ec6940ee82e4df56e3bd8fa86f0ef1f55a3425e213136baacL375) [[4]](diffhunk://#diff-7dc968e8de79939ec6940ee82e4df56e3bd8fa86f0ef1f55a3425e213136baacL384-L417) [[5]](diffhunk://#diff-7dc968e8de79939ec6940ee82e4df56e3bd8fa86f0ef1f55a3425e213136baacL630) [[6]](diffhunk://#diff-081e24824598e8b8d6b982c5bf2d7cccfef6810eef700fc7b0481321d33b88faL22-L24) [[7]](diffhunk://#diff-081e24824598e8b8d6b982c5bf2d7cccfef6810eef700fc7b0481321d33b88faL33-L47) [[8]](diffhunk://#diff-081e24824598e8b8d6b982c5bf2d7cccfef6810eef700fc7b0481321d33b88faL56-L72) [[9]](diffhunk://#diff-081e24824598e8b8d6b982c5bf2d7cccfef6810eef700fc7b0481321d33b88faL171-L186)

**Delete Dialog Improvements:**
- Added a new `isLocked` prop to `DeleteBettingDialog` to prevent deletion when a round is locked, and updated dialog content logic accordingly.

**Code Cleanup and Refactoring:**
- Removed unused imports such as `moment` from `InlineEditable.tsx`.
- Cleaned up local state and props related to previously removed restrictions in both `BettingRounds.tsx` and `InlineEditable.tsx`. [[1]](diffhunk://#diff-7dc968e8de79939ec6940ee82e4df56e3bd8fa86f0ef1f55a3425e213136baacL94) [[2]](diffhunk://#diff-081e24824598e8b8d6b982c5bf2d7cccfef6810eef700fc7b0481321d33b88faL22-L24) [[3]](diffhunk://#diff-081e24824598e8b8d6b982c5bf2d7cccfef6810eef700fc7b0481321d33b88faL33-L47) [[4]](diffhunk://#diff-081e24824598e8b8d6b982c5bf2d7cccfef6810eef700fc7b0481321d33b88faL56-L72) [[5]](diffhunk://#diff-081e24824598e8b8d6b982c5bf2d7cccfef6810eef700fc7b0481321d33b88faL112-R86)

**Minor Enhancements:**
- Updated the preview data for betting round options to include `id` and a default `userBet` object.