### PR TITLE
Update BetCard and AdminManagement components to replace 'Event' with 'Pick' terminology; enhance StreamTable and UserDropdown for better user experience; adjust HomePromotedBets and PromoCard layout; add cadeCoinUsersCount to BetCard type.

### DIFF
--- a/src/components/BetCard.tsx
+++ b/src/components/BetCard.tsx
@@ -5,7 +5,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { getImageLink } from '@/utils/helper';
 import { cn } from '@/lib/utils';
 import { Link } from 'react-router-dom';
-import { Video } from 'lucide-react';
+import { Video, Users } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { useEffect, useMemo, useState } from 'react';
 import { QuickPickModal } from './stream/QuickPickModal';
@@ -336,7 +336,7 @@ export default function BetCard(props: BetCardType) {
       </CardContent>
       <CardFooter className="mt-auto p-6 pt-0 px-4 gap-2">
         <div className="flex flex-col justify-between gap-3 w-full">
-          <div className='flex w-full justify-between'>
+          <div className='flex w-full justify-between items-center gap-2'>
             <Tooltip delayDuration={0}>
               <TooltipTrigger asChild>
                 <div className="flex gap-2 items-center text-gray-400 cursor-pointer">
@@ -356,6 +356,17 @@ export default function BetCard(props: BetCardType) {
               </TooltipTrigger>
               <TooltipContent side="right">Total Pot</TooltipContent>
             </Tooltip>
+            {cardData.cadeCoinUsersCount !== undefined && cardData.cadeCoinUsersCount > 0 && (
+              <Tooltip delayDuration={0}>
+                <TooltipTrigger asChild>
+                  <div className="flex gap-1 items-center text-primary text-sm cursor-pointer">
+                    <Users className="h-4 w-4" />
+                    <span className="font-semibold text-primary">{cardData.cadeCoinUsersCount}</span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="top">Total users with Picks</TooltipContent>
+              </Tooltip>
+            )}
             {props.betRoundType && <Badge className={cn("text-[10px] border", getBetRoundTypeClass(props.betRoundType))}>{getBetRoundTypeLabel(props.betRoundType)}</Badge>}
           </div>
           {cardData.lockDate && (

--- a/src/components/admin/AdminManagement.tsx
+++ b/src/components/admin/AdminManagement.tsx
@@ -138,7 +138,7 @@ export const AdminManagement = ({
     onError: (error: any) => {
       toast({
         title: 'Error',
-        description: getMessage(error) || 'Failed to create event',
+        description: getMessage(error) || 'Failed to create Pick',
         variant: 'destructive',
       });
     },
@@ -156,7 +156,7 @@ export const AdminManagement = ({
     onError: (error: any) => {
       toast({
         title: 'Error',
-        description: getMessage(error) || 'Failed to create event',
+        description: getMessage(error) || 'Failed to create Pick',
         variant: 'destructive',
       });
     },
@@ -1022,8 +1022,8 @@ export const AdminManagement = ({
                       ? 'Edit your Picks options'
                       : 'Create your Picks options'
                     : editStreamId
-                      ? 'Manage Event'
-                      : 'Create Event'}
+                      ? 'Manage Pick'
+                      : 'Create Pick'}
                 </span>
                 {/* Step 1: Next button, Step 2: Submit button */}
                 {createStep === 'info' ? (
@@ -1483,7 +1483,7 @@ export const AdminManagement = ({
                       setShowBettingValidation(false);
                     }}
                   >
-                    Create Event
+                    Create Pick
                   </button>
                 </div>
               )}
@@ -1522,7 +1522,7 @@ export const AdminManagement = ({
                       setShowBettingValidation(false);
                     }}
                   >
-                    Create Event
+                    Create Pick
                   </button>
                 </div>
               )}

--- a/src/components/admin/StreamTable.tsx
+++ b/src/components/admin/StreamTable.tsx
@@ -295,16 +295,18 @@ export const StreamTable: React.FC<Props> = ({
                   <div className="flex justify-between items-center pt-2 border-t border-gray-800">
                     <span className="text-sm text-muted-foreground">Actions:</span>
                     <div className="flex gap-3">
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Eye
-                            size={16}
-                            className="cursor-pointer transition-colors text-[#FFFFFFBF] hover:text-[#BDFF00]"
-                            onClick={() => setViewStreamId(stream?.id)}
-                          />
-                        </TooltipTrigger>
-                        <TooltipContent>View stream</TooltipContent>
-                      </Tooltip>
+                      {!isPromoTab && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Eye
+                              size={16}
+                              className="cursor-pointer transition-colors text-[#FFFFFFBF] hover:text-[#BDFF00]"
+                              onClick={() => setViewStreamId(stream?.id)}
+                            />
+                          </TooltipTrigger>
+                          <TooltipContent>View stream</TooltipContent>
+                        </Tooltip>
+                      )}
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <Pen
@@ -326,16 +328,18 @@ export const StreamTable: React.FC<Props> = ({
                         </TooltipTrigger>
                         <TooltipContent>Manage stream</TooltipContent>
                       </Tooltip>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <ChartNoAxesColumnIncreasing
-                            size={16}
-                            className="cursor-pointer transition-colors text-[#FFFFFFBF] hover:text-[#BDFF00]"
-                            onClick={() => setStreamAnalyticsId(stream?.id)}
-                          />
-                        </TooltipTrigger>
-                        <TooltipContent>Stream analytics</TooltipContent>
-                      </Tooltip>
+                      {!isPromoTab && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <ChartNoAxesColumnIncreasing
+                              size={16}
+                              className="cursor-pointer transition-colors text-[#FFFFFFBF] hover:text-[#BDFF00]"
+                              onClick={() => setStreamAnalyticsId(stream?.id)}
+                            />
+                          </TooltipTrigger>
+                          <TooltipContent>Stream analytics</TooltipContent>
+                        </Tooltip>
+                      )}
                       {/* <Lock color="#FFFFFFBF" size={16} className="cursor-pointer" />
                        <Play color="#FFFFFFBF" size={16} className="cursor-pointer" /> */}
                       {stream?.streamStatus === StreamStatus.SCHEDULED && (
@@ -366,7 +370,7 @@ export const StreamTable: React.FC<Props> = ({
                 <TableHead>{isPromoTab ? 'Promo Card Title' : 'Stream Title'}</TableHead>
                 {!isPromoTab && <TableHead>Stream Status</TableHead>}
                 <TableHead>{isPromoTab ? 'Tagged Creator' : 'Stream Creator'}</TableHead>
-                {!isPromoTab && <TableHead>Picking Status</TableHead>}
+                {!isPromoTab && <TableHead>Pick Status</TableHead>}
                 {!isPromoTab && <TableHead>Users</TableHead>}
                 <TableHead>Actions</TableHead>
                 {isAdmin && <TableHead>Promoted</TableHead>}
@@ -391,16 +395,18 @@ export const StreamTable: React.FC<Props> = ({
                     {!isPromoTab && <TableCell>{stream?.userBetCount}</TableCell>}
                     <TableCell>
                       <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Eye
-                              size={18}
-                              className="cursor-pointer transition-colors text-[#FFFFFFBF] hover:text-[#BDFF00]"
-                              onClick={() => setViewStreamId(stream?.id)}
-                            />
-                          </TooltipTrigger>
-                          <TooltipContent>View stream</TooltipContent>
-                        </Tooltip>
+                        {!isPromoTab && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Eye
+                                size={18}
+                                className="cursor-pointer transition-colors text-[#FFFFFFBF] hover:text-[#BDFF00]"
+                                onClick={() => setViewStreamId(stream?.id)}
+                              />
+                            </TooltipTrigger>
+                            <TooltipContent>View stream</TooltipContent>
+                          </Tooltip>
+                        )}
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <Pen
@@ -422,16 +428,18 @@ export const StreamTable: React.FC<Props> = ({
                           </TooltipTrigger>
                           <TooltipContent>Manage stream</TooltipContent>
                         </Tooltip>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <ChartNoAxesColumnIncreasing
-                              size={18}
-                              className="cursor-pointer transition-colors text-[#FFFFFFBF] hover:text-[#BDFF00]"
-                              onClick={() => setStreamAnalyticsId(stream?.id)}
-                            />
-                          </TooltipTrigger>
-                          <TooltipContent>Stream analytics</TooltipContent>
-                        </Tooltip>
+                        {!isPromoTab && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <ChartNoAxesColumnIncreasing
+                                size={18}
+                                className="cursor-pointer transition-colors text-[#FFFFFFBF] hover:text-[#BDFF00]"
+                                onClick={() => setStreamAnalyticsId(stream?.id)}
+                              />
+                            </TooltipTrigger>
+                            <TooltipContent>Stream analytics</TooltipContent>
+                          </Tooltip>
+                        )}
                         {/* <Lock color="#FFFFFFBF" size={18} />
                        <Play color="#FFFFFFBF" size={18} /> */}
                         {stream?.streamStatus === StreamStatus.SCHEDULED && (

--- a/src/components/creator/CreatorManagement.tsx
+++ b/src/components/creator/CreatorManagement.tsx
@@ -126,7 +126,7 @@ export const CreatorManagement = ({
     onError: (error: any) => {
       toast({
         title: 'Error',
-        description: getMessage(error) || 'Failed to create event',
+        description: getMessage(error) || 'Failed to create Pick',
         variant: 'destructive',
       });
     },
@@ -144,7 +144,7 @@ export const CreatorManagement = ({
     onError: (error: any) => {
       toast({
         title: 'Error',
-        description: getMessage(error) || 'Failed to create event',
+        description: getMessage(error) || 'Failed to create Pick',
         variant: 'destructive',
       });
     },
@@ -1004,8 +1004,8 @@ export const CreatorManagement = ({
                       ? 'Edit your Picks options'
                       : 'Create your Picks options'
                     : editStreamId
-                      ? 'Manage Event'
-                      : 'Create Event'}
+                      ? 'Manage Pick'
+                      : 'Create Pick'}
                 </span>
                 {/* Step 1: Next button, Step 2: Submit button */}
                 {createStep === 'info' ? (
@@ -1392,7 +1392,7 @@ export const CreatorManagement = ({
                     setShowBettingValidation(false);
                   }}
                 >
-                  Create Event
+                  Create Pick
                 </button>
               </div>
             )}
@@ -1431,7 +1431,7 @@ export const CreatorManagement = ({
                     setShowBettingValidation(false);
                   }}
                 >
-                  Create Event
+                  Create Pick
                 </button>
               </div>
             )}

--- a/src/components/home/HomePromotedBets.tsx
+++ b/src/components/home/HomePromotedBets.tsx
@@ -54,11 +54,11 @@ export default function HomePromotedBets() {
     <>
       {/* Promo Cards Carousel - Shows above featured carousel */}
       {isLoading ? (
-        <div className="px-2 mb-6">
+        <div className="mb-6 w-full md:w-3/4 md:mx-auto px-2">
           <Skeleton className="w-full h-[200px] md:h-[150px] lg:min-h-[200px] rounded-lg" />
         </div>
       ) : promoCards.length > 0 && (
-        <div className="px-2 mb-6">
+        <div className="mb-6 w-full md:w-3/4 md:mx-auto px-2">
           <Carousel
             opts={{
               align: 'start',

--- a/src/components/home/PromoCard.tsx
+++ b/src/components/home/PromoCard.tsx
@@ -24,8 +24,7 @@ export default function PromoCard({
 
   return (
     <Card className={cn(
-      "overflow-hidden bg-card-grid-bg border border-primary/50",
-      isMobile ? "w-full" : "w-3/4 mx-auto",
+      "overflow-hidden bg-card-grid-bg border border-primary/50 w-full",
       className
     )}>
       <div 

--- a/src/components/navigation/UserDropdown.tsx
+++ b/src/components/navigation/UserDropdown.tsx
@@ -96,7 +96,7 @@ export const UserDropdown = ({ profile, onLogout }: UserDropdownProps) => {
           <DropdownMenuItem asChild className="cursor-pointer">
             <div className="flex gap-1 group">
               <Plus className="h-4 w-4 text-[#B4FF39] group-hover:text-black transition-colors" />
-              <Link to="/creator?createStream=true" className="w-full font-semibold text-[#B4FF39] group-hover:text-black transition-colors">Create Event</Link>
+              <Link to="/creator?createStream=true" className="w-full font-semibold text-[#B4FF39] group-hover:text-black transition-colors">Create Pick</Link>
             </div>
           </DropdownMenuItem>
         }

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -197,7 +197,7 @@ export default function Profile() {
                         type="button"
                         className="ml-auto self-end bg-primary text-black text-sm font-bold px-4 py-2 rounded-full hover:bg-opacity-90 transition-colors h-fit w-full md:w-fit"
                       >
-                        Create Event
+                        Create Pick
                       </button>
                     </Link>
                   )}

--- a/src/types/bet.ts
+++ b/src/types/bet.ts
@@ -21,6 +21,7 @@ export interface BetCard {
     goldCoins: number;
     cadeCoins: number;
   },
+  cadeCoinUsersCount?: number;
   creator: string | null;
   streamId?: string | null;
   roundId?: string | null;


### PR DESCRIPTION
Note: goes with PR https://github.com/Streambet-LLC/streambet_api/pull/198

This pull request primarily updates terminology throughout the app, changing references from "Event" to "Pick" for consistency, and introduces a new user count indicator for Cade Coin picks on bet cards. It also improves the UI by conditionally rendering certain actions and analytics in admin tables and adjusts layout for promoted bet cards.

**Terminology updates ("Event" → "Pick"):**
* Updated all user-facing labels, button texts, and error messages from "Event" to "Pick" in admin, creator, navigation, and profile components for consistency. [[1]](diffhunk://#diff-1234409323881471ea5909d87ddcadb28093fe3926259c851b0065d6ae20227eL141-R141) [[2]](diffhunk://#diff-1234409323881471ea5909d87ddcadb28093fe3926259c851b0065d6ae20227eL159-R159) [[3]](diffhunk://#diff-1234409323881471ea5909d87ddcadb28093fe3926259c851b0065d6ae20227eL1025-R1026) [[4]](diffhunk://#diff-1234409323881471ea5909d87ddcadb28093fe3926259c851b0065d6ae20227eL1486-R1486) [[5]](diffhunk://#diff-1234409323881471ea5909d87ddcadb28093fe3926259c851b0065d6ae20227eL1525-R1525) [[6]](diffhunk://#diff-6e8119a1b0dca99942a86afbc9a3b94dcff025a9abfad57c3f1be59d6a2a2bcbL129-R129) [[7]](diffhunk://#diff-6e8119a1b0dca99942a86afbc9a3b94dcff025a9abfad57c3f1be59d6a2a2bcbL147-R147) [[8]](diffhunk://#diff-6e8119a1b0dca99942a86afbc9a3b94dcff025a9abfad57c3f1be59d6a2a2bcbL1007-R1008) [[9]](diffhunk://#diff-6e8119a1b0dca99942a86afbc9a3b94dcff025a9abfad57c3f1be59d6a2a2bcbL1395-R1395) [[10]](diffhunk://#diff-6e8119a1b0dca99942a86afbc9a3b94dcff025a9abfad57c3f1be59d6a2a2bcbL1434-R1434) [[11]](diffhunk://#diff-1b29ad2edddb29892180958e09a54d48d8dc705b8f6f88a1bb584eead2d46c8dL99-R99) [[12]](diffhunk://#diff-991fd67e5b3fed788072c54ea29e8c8635869a9ad427430130fb06cfe8f4199bL200-R200) [[13]](diffhunk://#diff-4d767014426e1f181f4a175c933df2b57410a76e9fa2ed21271d5b979ef31d37L369-R373)

**BetCard enhancements:**
* Added a new `cadeCoinUsersCount` property to the `BetCard` type and displayed a tooltip with the number of users who have made Cade Coin picks, including a "Users" icon, on the bet card UI. [[1]](diffhunk://#diff-b962d5993336fe06b37328b85bff8eb47cb1f0f396265fd152d5a766f879bed5R24) [[2]](diffhunk://#diff-4b2fa285a7aa410025e2e18be6aad42f28ce32fe5e2c9d281d0dbd73ce23b651L8-R8) [[3]](diffhunk://#diff-4b2fa285a7aa410025e2e18be6aad42f28ce32fe5e2c9d281d0dbd73ce23b651R359-R369)
* Improved the layout of the BetCard footer for better alignment and spacing.

**Admin Stream Table improvements:**
* Conditionally rendered "View stream" and "Stream analytics" actions only when not in the promo tab, both in the table header and row actions, to declutter the UI for promo cards. [[1]](diffhunk://#diff-4d767014426e1f181f4a175c933df2b57410a76e9fa2ed21271d5b979ef31d37R298) [[2]](diffhunk://#diff-4d767014426e1f181f4a175c933df2b57410a76e9fa2ed21271d5b979ef31d37R309) [[3]](diffhunk://#diff-4d767014426e1f181f4a175c933df2b57410a76e9fa2ed21271d5b979ef31d37R331) [[4]](diffhunk://#diff-4d767014426e1f181f4a175c933df2b57410a76e9fa2ed21271d5b979ef31d37R342) [[5]](diffhunk://#diff-4d767014426e1f181f4a175c933df2b57410a76e9fa2ed21271d5b979ef31d37R398) [[6]](diffhunk://#diff-4d767014426e1f181f4a175c933df2b57410a76e9fa2ed21271d5b979ef31d37R409) [[7]](diffhunk://#diff-4d767014426e1f181f4a175c933df2b57410a76e9fa2ed21271d5b979ef31d37R431) [[8]](diffhunk://#diff-4d767014426e1f181f4a175c933df2b57410a76e9fa2ed21271d5b979ef31d37R442)
* Updated the table column header from "Picking Status" to "Pick Status" for clarity.

**Promoted bet cards layout:**
* Adjusted the layout of promoted bet cards and their loading skeleton to center them and set a consistent width across screen sizes. [[1]](diffhunk://#diff-1e5da1120b2c815d06d24f57742c5cc1195bb1611eb019041870d662361728eeL57-R61) [[2]](diffhunk://#diff-16272266c6f7fded54448d34f434703f3903e767c4f94d3b8aaf4ebeed6b6fbeL27-R27)