### PR TITLE
Enhance scrolling behavior in HomeBets component for better user experience; adjust BetCard layout and tooltip content for clarity.

### DIFF
--- a/src/components/BetCard.tsx
+++ b/src/components/BetCard.tsx
@@ -337,36 +337,38 @@ export default function BetCard(props: BetCardType) {
       <CardFooter className="mt-auto p-6 pt-0 px-4 gap-2">
         <div className="flex flex-col justify-between gap-3 w-full">
           <div className='flex w-full justify-between items-center gap-2'>
-            <Tooltip delayDuration={0}>
-              <TooltipTrigger asChild>
-                <div className="flex gap-2 items-center text-gray-400 cursor-pointer">
-                  {/* <div className="flex gap-2 text-sm items-center">
-                    <img src="/icons/sweep-coins.png" alt="Stream Coins" className="h-3 w-5" />
-                    <span className="text-creator-green font-semibold">{cardData.totalPot.streamCoins}</span>
-                  </div>
-                  <div className="flex gap-1 text-sm items-center">
-                    <img src="/icons/cade-coins.png" alt="gold-coins" className="h-4 w-4" />
-                    <span className="text-gold-coin font-semibold">{cardData.totalPot.goldCoins}</span>
-                  </div> */}
-                  <div className="flex gap-1 text-sm items-center">
-                    <img src="/icons/cade-coins.png" alt="gold-coins" className="h-4 w-4" />
-                    <span className="text-[#B4FF39] font-semibold">{cardData.totalPot.cadeCoins || 0}</span>
-                  </div>
-                </div>
-              </TooltipTrigger>
-              <TooltipContent side="right">Total Pot</TooltipContent>
-            </Tooltip>
-            {cardData.cadeCoinUsersCount !== undefined && cardData.cadeCoinUsersCount > 0 && (
+            <div className="flex gap-2 items-center">
               <Tooltip delayDuration={0}>
                 <TooltipTrigger asChild>
-                  <div className="flex gap-1 items-center text-primary text-sm cursor-pointer">
-                    <Users className="h-4 w-4" />
-                    <span className="font-semibold text-primary">{cardData.cadeCoinUsersCount}</span>
+                  <div className="flex gap-2 items-center text-gray-400 cursor-pointer">
+                    {/* <div className="flex gap-2 text-sm items-center">
+                      <img src="/icons/sweep-coins.png" alt="Stream Coins" className="h-3 w-5" />
+                      <span className="text-creator-green font-semibold">{cardData.totalPot.streamCoins}</span>
+                    </div>
+                    <div className="flex gap-1 text-sm items-center">
+                      <img src="/icons/cade-coins.png" alt="gold-coins" className="h-4 w-4" />
+                      <span className="text-gold-coin font-semibold">{cardData.totalPot.goldCoins}</span>
+                    </div> */}
+                    <div className="flex gap-1 text-sm items-center">
+                      <img src="/icons/cade-coins.png" alt="gold-coins" className="h-4 w-4" />
+                      <span className="text-[#B4FF39] font-semibold">{cardData.totalPot.cadeCoins || 0}</span>
+                    </div>
                   </div>
                 </TooltipTrigger>
-                <TooltipContent side="top">Total users with Picks</TooltipContent>
+                <TooltipContent side="top">Total Pot</TooltipContent>
               </Tooltip>
-            )}
+              {cardData.cadeCoinUsersCount !== undefined && cardData.cadeCoinUsersCount > 0 && (
+                <Tooltip delayDuration={0}>
+                  <TooltipTrigger asChild>
+                    <div className="flex gap-1 items-center text-primary text-sm cursor-pointer">
+                      <Users className="h-4 w-4 text-gray-300" />
+                      <span className="font-semibold text-primary">{cardData.cadeCoinUsersCount}</span>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">Total users with Picks</TooltipContent>
+                </Tooltip>
+              )}
+            </div>
             {props.betRoundType && <Badge className={cn("text-[10px] border", getBetRoundTypeClass(props.betRoundType))}>{getBetRoundTypeLabel(props.betRoundType)}</Badge>}
           </div>
           {cardData.lockDate && (

--- a/src/components/home/HomeBets.tsx
+++ b/src/components/home/HomeBets.tsx
@@ -85,7 +85,22 @@ export default function HomeBets({
     if (!tabsRef.current) return;
 
     if (selectedCategory !== undefined) {
-      tabsRef.current.scrollIntoView({ behavior: 'smooth' });
+      const scrollContainer = tabsRef.current.closest('main');
+      if (!scrollContainer) return;
+      
+      const elementRect = tabsRef.current.getBoundingClientRect();
+      const containerRect = scrollContainer.getBoundingClientRect();
+      
+      // Calculate the position of the element within the scroll container
+      const relativeTop = elementRect.top - containerRect.top;
+      
+      // Calculate target scroll position with offset (80px from top of container so hero section doesn't get hidden)
+      const targetScrollTop = scrollContainer.scrollTop + relativeTop - 80;
+      
+      scrollContainer.scrollTo({
+        top: targetScrollTop,
+        behavior: 'smooth'
+      });
     }
   }, [selectedCategory]);
 


### PR DESCRIPTION
This pull request introduces UI improvements to the `BetCard` and enhances the scrolling behavior in the `HomeBets` component. The most important changes are grouped below:

**UI Improvements in `BetCard`:**

* Changed the tooltip position for the "Total Pot" indicator from the right to the top for better visibility.
* Updated the `Users` icon color in the tooltip to `text-gray-300` for improved contrast and visual clarity.
* Refactored the layout by wrapping related elements in a flex container to improve alignment and spacing.

**Scrolling Behavior Enhancement in `HomeBets`:**

* Improved the scroll behavior when a category is selected: now, the relevant tabs scroll smoothly into view within the nearest `main` container, with an 80px offset to prevent the hero section from being hidden.