### PR TITLE
harmonize date formatting across BetCard and helper functions

### DIFF
--- a/src/components/BetCard.tsx
+++ b/src/components/BetCard.tsx
@@ -342,7 +342,7 @@ export default function BetCard(props: BetCardType) {
                 status="lock"
                 lockDate={(() => {
                   const date = new Date(cardData.lockDate);
-                  const formattedDate = moment(cardData.lockDate).format('MMM D, YYYY [at] h:mm A');
+                  const formattedDate = moment(cardData.lockDate).format('MMM D [at] h:mm A');
                   const timezone = date
                     .toLocaleTimeString('en-US', { timeZoneName: 'short' })
                     .split(' ')

--- a/src/utils/betRoundHelpers.ts
+++ b/src/utils/betRoundHelpers.ts
@@ -12,9 +12,9 @@ export const getBetRoundTypeLabel = (type: BetRoundType): string => {
 
 export const getBetRoundTypeClass = (type: BetRoundType): string => {
   const classes: Record<BetRoundType, string> = {
-    [BetRoundType.AUCTION]: 'bg-orange-500/10 text-orange-500 border-orange-500/20 hover:bg-orange-500/20',
+    [BetRoundType.AUCTION]: 'bg-fuchsia-500/10 text-fuchsia-500 border-fuchsia-500/20 hover:bg-fuchsia-500/20',
     [BetRoundType.FUTURE]: 'bg-cyan-500/10 text-cyan-500 border-cyan-500/20 hover:bg-cyan-500/20',
-    [BetRoundType.OPINION]: 'bg-purple-500/10 text-purple-500 border-purple-500/20 hover:bg-purple-500/20',
+    [BetRoundType.OPINION]: 'bg-blue-500/10 text-blue-500 border-blue-500/20 hover:bg-blue-500/20',
     [BetRoundType.PICK]: 'bg-[#bdff00]/10 text-[#bdff00] border-[#bdff00]/20 hover:bg-[#bdff00]/20',
   };
   return classes[type];

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -169,7 +169,7 @@ export function formatTime(dateString: string) {
 
 export function formatDate(dateString: string) {
   const date = new Date(dateString);
-  return format(date, 'EEEE, MMM do, yyyy');
+  return format(date, 'MMM d');
 };
 
 export function formatDateTime(dateString: string) {


### PR DESCRIPTION
This pull request makes several UI-related adjustments to date formatting and bet round type styling to improve consistency and clarity across the application. The main changes focus on simplifying date displays and updating color schemes for different bet round types.

Date formatting improvements:

* Simplified the date format in the `formatDate` function from `'EEEE, MMM do, yyyy'` to `'MMM d'`, making date displays more concise in `src/utils/helper.ts`.
* Updated the lock date display in `BetCard` to use the format `'MMM D [at] h:mm A'` instead of including the year, for a cleaner presentation in `src/components/BetCard.tsx`.

Bet round type styling updates:

* Changed the color scheme for the `AUCTION` bet round type from orange to fuchsia, and for the `OPINION` type from purple to blue, to better differentiate round types in `src/utils/betRoundHelpers.ts`.