### PR TITLE
refactor: update header to use image for CardCade branding and improve layout

### DIFF
--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -54,20 +54,22 @@ export default function Home() {
         </div>
 
         <div className="max-w-3xl mx-auto text-center space-y-4 p-4">
-          <h1 className="text-4xl md:text-5xl font-bold">
-            <motion.span
+          <h1 className="text-4xl md:text-5xl font-bold flex justify-center">
+            <motion.div
               className="relative inline-block"
               whileHover={shouldReduceMotion ? undefined : { scale: 1.05 }}
             >
-              <motion.span
+              <motion.div
                 className="absolute inset-0 bg-gradient-to-r from-electric-lime to-creator-green blur-lg opacity-30"
                 animate={shouldReduceMotion ? undefined : { scale: [1, 1.2, 1] }}
                 transition={shouldReduceMotion ? undefined : { duration: 3, repeat: Infinity }}
               />
-              <span className="relative bg-gradient-to-r from-electric-lime to-creator-green bg-clip-text text-transparent">
-                cardcade
-              </span>
-            </motion.span>
+              <img
+                src="/wordmark.svg"
+                alt="CardCade"
+                className="relative h-12 md:h-16 w-auto object-contain"
+              />
+            </motion.div>
           </h1>
           <div className="space-y-2">
             <p className="text-[#FFFFFFBF]">


### PR DESCRIPTION
This pull request updates the homepage header to use a branded wordmark image in place of the previous styled text. The change improves visual consistency and branding by replacing the gradient text with the `wordmark.svg` image, while preserving the animated background effect.

Homepage header branding update:

* Replaced the gradient-styled "cardcade" text with a branded `wordmark.svg` image, maintaining the animated gradient background effect by switching from `motion.span` to `motion.div` components in the `Home.tsx` file.