### PR TITLE
add formatCoinAmount utility and update BetCard to use formatted coin amounts

### DIFF
--- a/src/components/BetCard.tsx
+++ b/src/components/BetCard.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from './ui/card'
 import FeaturedBetCard from './FeaturedBetCard';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { getImageLink } from '@/utils/helper';
+import { roundDownCoinAmount } from '@/utils/format';
 import { cn } from '@/lib/utils';
 import { Link, useNavigate } from 'react-router-dom';
 import { Video, Users, Expand } from 'lucide-react';
@@ -389,7 +390,7 @@ export default function BetCard(props: BetCardType) {
                   <div className="text-xs py-1 text-electric-lime">
                     {props.mechanism?.toLowerCase?.() === 'sentiment'
                       ? 'Your pick'
-                      : `Your pick for ${option.userBet.amount} Cade Coins`}
+                      : `Your pick for ${roundDownCoinAmount(option.userBet.amount)} CadeCoins`}
                   </div>
                 )}
               </div>
@@ -440,17 +441,19 @@ export default function BetCard(props: BetCardType) {
                   {/* Hide CadeCoin pool for sentiment picks */}
                   {props.mechanism?.toLowerCase?.() !== 'sentiment' && (
                     <>
-                      <Tooltip delayDuration={0}>
-                        <TooltipTrigger asChild>
-                          <div className="flex gap-1 text-sm items-center cursor-pointer">
-                            <img src="/icons/cade-coins.png" alt="gold-coins" className="h-4 w-4" />
-                            <span className="text-[#B4FF39] font-semibold">
-                              {cardData.totalPot.cadeCoins || 0}
-                            </span>
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent side="top">Total Pot</TooltipContent>
-                      </Tooltip>
+                      {roundDownCoinAmount(cardData.totalPot.cadeCoins) > 0 && (
+                        <Tooltip delayDuration={0}>
+                          <TooltipTrigger asChild>
+                            <div className="flex gap-1 text-sm items-center cursor-pointer">
+                              <img src="/icons/cade-coins.png" alt="gold-coins" className="h-4 w-4" />
+                              <span className="text-[#B4FF39] font-semibold">
+                                {roundDownCoinAmount(cardData.totalPot.cadeCoins)}
+                              </span>
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent side="top">Total Pot</TooltipContent>
+                        </Tooltip>
+                      )}
                       {cardData.cadeCoinUsersCount !== undefined &&
                         cardData.cadeCoinUsersCount > 0 && (
                           <Tooltip delayDuration={0}>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,9 +10,9 @@ export const Footer = () => {
           {/* Company Info */}
           <div className="space-y-4">
             <img src="/machine-wordmark.svg" alt="CardCade Logo" className="mb-8" />
-            <p className="text-sm text-muted-foreground">
+            {/* <p className="text-sm text-muted-foreground">
               Live picks for games created on the Internet.
-            </p>
+            </p> */}
           </div>
 
           {/* Legal Links */}

--- a/src/components/navigation/UserDropdown.tsx
+++ b/src/components/navigation/UserDropdown.tsx
@@ -100,9 +100,9 @@ export const UserDropdown = ({ profile, onLogout }: UserDropdownProps) => {
             </div>
           </DropdownMenuItem>
         }
-        <DropdownMenuItem asChild className="cursor-pointer">
+        {/* <DropdownMenuItem asChild className="cursor-pointer">
           <Link to={`/${profile?.username}`}>My Profile</Link>
-        </DropdownMenuItem>
+        </DropdownMenuItem> */}
 
         <DropdownMenuItem asChild className="cursor-pointer">
           <Link to="/daily-spin">Daily Spin</Link>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -87,3 +87,10 @@ export const formatViewCount = (count: number): string => {
 export const formatUrl = (url: string): string => {
   return !url.startsWith("https://") && !url.startsWith("http://") ? "https://".concat(url) : url;
 };
+
+/**
+ * Round down coin amount to nearest whole number
+ */
+export const roundDownCoinAmount = (amount: number | undefined | null): number => {
+  return Math.floor(amount ?? 0);
+};


### PR DESCRIPTION
This pull request introduces a utility function to consistently round down coin amounts and applies it throughout the `BetCard` component to ensure displayed values are always whole numbers. Additionally, some UI text and navigation options have been temporarily commented out.

**BetCard Coin Display Improvements:**

* Added a new utility function `roundDownCoinAmount` in `src/utils/format.ts` to round down coin amounts to the nearest whole number, ensuring consistency in displayed coin values.
* Updated `BetCard` (`src/components/BetCard.tsx`) to use `roundDownCoinAmount` when displaying user bet amounts and the total pot, so fractional coin values are no longer shown to users. [[1]](diffhunk://#diff-4b2fa285a7aa410025e2e18be6aad42f28ce32fe5e2c9d281d0dbd73ce23b651L392-R393) [[2]](diffhunk://#diff-4b2fa285a7aa410025e2e18be6aad42f28ce32fe5e2c9d281d0dbd73ce23b651R444-R456)
* Ensured that the CadeCoin pool is only displayed if the rounded-down total pot is greater than zero, preventing display of zero or negative values.

**UI and Navigation Adjustments:**

* Temporarily commented out the company info tagline in the `Footer` component, possibly for design or content review reasons.
* Temporarily commented out the "My Profile" link in the user dropdown navigation, likely pending further changes or fixes.