### PR TITLE
feat: add One Piece category to betting options and update related ma…

### DIFF
--- a/src/components/sidebar/SidebarBody.tsx
+++ b/src/components/sidebar/SidebarBody.tsx
@@ -10,6 +10,7 @@ import {
   LayoutGrid,
   GemIcon,
   Flame,
+  Swords,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useQuery } from '@tanstack/react-query';
@@ -41,6 +42,7 @@ interface SidebarBodyProps {
 // Mapping between BettingCategory (used in sidebar UI) and PrizeBrand (used in database)
 const CATEGORY_TO_BRAND_MAP: Record<BettingCategory, PrizeBrand> = {
   [BettingCategory.POKEMON_CARDS]: 'pokemon',
+  [BettingCategory.ONE_PIECE]: 'one_piece',
   [BettingCategory.SPORTS_CARDS]: 'sports',
   [BettingCategory.OTHER]: 'other',
 };
@@ -48,9 +50,9 @@ const CATEGORY_TO_BRAND_MAP: Record<BettingCategory, PrizeBrand> = {
 // Reverse mapping for highlighting selected category from URL brand param
 const BRAND_TO_CATEGORY_MAP: Record<string, BettingCategory> = {
   'pokemon': BettingCategory.POKEMON_CARDS,
+  'one_piece': BettingCategory.ONE_PIECE,
   'sports': BettingCategory.SPORTS_CARDS,
   'other': BettingCategory.OTHER,
-  'one_piece': BettingCategory.OTHER, // fallback
 };
 
 const CategoryIconContainer = ({
@@ -233,6 +235,7 @@ export default function SidebarBody({
   const getCategoryIcon = (category: BettingCategory) => {
     const iconMap = {
       [BettingCategory.POKEMON_CARDS]: LayoutGrid,
+      [BettingCategory.ONE_PIECE]: Swords,
       [BettingCategory.SPORTS_CARDS]: Goal,
       // HOTFIX: Temporarily removed from UI - backend still supports this
       // [BettingCategory.EMERGING_SPORTS]: SwordsIcon,

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -26,6 +26,7 @@ export enum BettingCategory {
   // TRADING_CARDS = 'trading_cards',
   // NEOSPORTS_ALTERNATIVE = 'neosports_alternative',
   POKEMON_CARDS = 'pokemon_cards',
+  ONE_PIECE = 'one_piece',
   SPORTS_CARDS = 'sports_cards',
   // SPORTS = 'sports',
   // HOTFIX: Temporarily removed from UI - backend still supports this

--- a/src/utils/categoryHelpers.ts
+++ b/src/utils/categoryHelpers.ts
@@ -5,6 +5,7 @@ export const getCategoryLabel = (category: BettingCategory): string => {
     // [BettingCategory.TRADING_CARDS]: 'Trading Cards',
     // [BettingCategory.NEOSPORTS_ALTERNATIVE]: 'Alternative Sports',
     [BettingCategory.POKEMON_CARDS]: 'Pokemon Cards',
+    [BettingCategory.ONE_PIECE]: 'One Piece',
     [BettingCategory.SPORTS_CARDS]: 'Sports Cards',
     // [BettingCategory.SPORTS]: 'Sports',
     // [BettingCategory.STREAMING_COMPETITIONS]: 'Streaming Competitions',


### PR DESCRIPTION
…ppings

This pull request adds support for the "One Piece" category throughout the codebase, ensuring it is properly mapped, displayed, and selectable in the sidebar UI. The changes touch on enum definitions, mapping logic, icon usage, and label display for the new category.

**Category Addition and Mapping**

* Added `ONE_PIECE` to the `BettingCategory` enum in `src/enums.ts`.
* Updated `CATEGORY_TO_BRAND_MAP` and `BRAND_TO_CATEGORY_MAP` in `src/components/sidebar/SidebarBody.tsx` to include the "One Piece" category, ensuring correct mapping between UI and backend values.

**UI Enhancements**

* Imported the `Swords` icon from `lucide-react` and used it for the "One Piece" category in the sidebar icon map in `src/components/sidebar/SidebarBody.tsx`. [[1]](diffhunk://#diff-4085b00e407831f389d6e4eaa30964e683810514732c07d365b8aefcdbc5224bR13) [[2]](diffhunk://#diff-4085b00e407831f389d6e4eaa30964e683810514732c07d365b8aefcdbc5224bR238)
* Added a label for the "One Piece" category in `getCategoryLabel` in `src/utils/categoryHelpers.ts` for proper display in the UI.