### PR TITLE
enhance ProfilePrizeProgress component to display tier fees and adjustments

### DIFF
--- a/src/components/how-to-play/cardData.tsx
+++ b/src/components/how-to-play/cardData.tsx
@@ -30,7 +30,7 @@ export const infoCards: InfoCard[] = [
     trailWord: 'FUN',
     description: (
       <>
-        Win prizes along the way by accumulating CadeCoins from buying, selling, and participating in predictions & games.
+        Win prizes along the way by accumulating CadeCoins from buying, selling, and participating in predictions & games. The more you buy and sell, the higher your discount tier climbs. As you level up, your seller fee can drop from 4% to 2% so you keep more on every sale.
       </>
     ),
   },

--- a/src/components/profile/ProfilePrizeProgress.tsx
+++ b/src/components/profile/ProfilePrizeProgress.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { cn } from '@/lib/utils';
+import { roundDownCoinAmount } from '@/utils/format';
 import { getPrizeColor } from '@/utils/prizeColors';
 
 interface ProfilePrizeProgressProps {
@@ -32,6 +33,16 @@ export default function ProfilePrizeProgress({
   const progressPercent = Math.min(100, (clampedLifetime / MAX_MILESTONE) * 100);
   const nextMilestone = MILESTONES.find((milestone) => clampedLifetime < milestone.amount);
   const currentSellerFee = getSellerFeeFromLifetime(clampedLifetime);
+  const tierFeeData = MILESTONES.map((milestone) => {
+    const feeAtTier = getSellerFeeFromLifetime(milestone.amount);
+    const feeDecreaseFromCurrent = Math.max(0, currentSellerFee - feeAtTier);
+
+    return {
+      ...milestone,
+      feeAtTier,
+      feeDecreaseFromCurrent,
+    };
+  });
 
   // Calculate tick mark positions for equal segments across the progress bar
   const getTickPosition = (index: number) => {
@@ -53,9 +64,14 @@ export default function ProfilePrizeProgress({
               alt="CadeCoins" 
               className="w-5 h-5"
             />
-            <span>Current: <span className="font-bold text-base">{currentCadeCoins.toLocaleString('en-US')}</span></span>
+            <span>Current: <span className="font-bold text-base">{roundDownCoinAmount(currentCadeCoins).toLocaleString('en-US')}</span></span>
             <span className="text-muted-foreground">|</span>
-            <span>Lifetime: <span className="font-bold text-base">{lifetimeCadeCoins.toLocaleString('en-US')}</span></span>
+            <img 
+              src="/icons/cade-coins.png" 
+              alt="CadeCoins" 
+              className="w-5 h-5"
+            />
+            <span>Lifetime: <span className="font-bold text-base">{roundDownCoinAmount(lifetimeCadeCoins).toLocaleString('en-US')}</span></span>
           </div>
           
           {nextMilestone ? (
@@ -75,7 +91,7 @@ export default function ProfilePrizeProgress({
                   </div>
                   
                   {/* Fixed tier tick marks */}
-                  {MILESTONES.map((milestone, index) => {
+                  {tierFeeData.map((milestone, index) => {
                     const position = getTickPosition(index);
                     const achieved = clampedLifetime >= milestone.amount;
                     const isLast = index === MILESTONES.length - 1;
@@ -100,11 +116,11 @@ export default function ProfilePrizeProgress({
                 </div>
               </div>
               
-              <div className="relative hidden sm:flex justify-between text-xs sm:text-sm font-bold mt-3">
+              <div className="relative hidden sm:flex justify-between text-xs sm:text-sm font-bold mt-4">
                 <span className="text-muted-foreground">{PROGRESS_START.toLocaleString('en-US')}</span>
                 
                 {/* Fixed tier labels */}
-                {MILESTONES.map((milestone, index) => {
+                {tierFeeData.map((milestone, index) => {
                   const position = getTickPosition(index);
                   const achieved = clampedLifetime >= milestone.amount;
                   const isLast = index === MILESTONES.length - 1;
@@ -113,7 +129,7 @@ export default function ProfilePrizeProgress({
                     <span 
                       key={milestone.amount}
                       className={cn(
-                        'absolute flex flex-col',
+                        'absolute flex flex-col leading-tight',
                         getPrizeColor(index, 'text'),
                         !achieved && 'opacity-50',
                         isLast ? 'items-end right-0' : 'items-center -translate-x-1/2'
@@ -122,11 +138,36 @@ export default function ProfilePrizeProgress({
                     >
                       <span className="text-xs sm:text-sm">{milestone.amount.toLocaleString('en-US')}</span>
                       <span className="text-[10px] sm:text-xs mt-0.5">{milestone.label}</span>
+                      <span className="text-[10px] sm:text-xs mt-0.5">
+                        Fee: {milestone.feeAtTier.toFixed(1)}% {achieved ? '(reached)' : `(-${milestone.feeDecreaseFromCurrent.toFixed(1)}%)`}
+                      </span>
                     </span>
                   );
                 })}
               </div>
-              <p className="text-center text-sm mt-8">
+              <div className="sm:hidden grid grid-cols-2 gap-3 mt-4">
+                {tierFeeData.map((milestone, index) => {
+                  const achieved = clampedLifetime >= milestone.amount;
+
+                  return (
+                    <div
+                      key={milestone.amount}
+                      className={cn(
+                        'rounded-md border p-2 text-xs',
+                        getPrizeColor(index, 'border'),
+                        !achieved && 'opacity-70'
+                      )}
+                    >
+                      <p className={cn('font-bold', getPrizeColor(index, 'text'))}>{milestone.label}</p>
+                      <p className="text-muted-foreground">{milestone.amount.toLocaleString('en-US')} coins</p>
+                      <p className="mt-1">
+                        Fee: {milestone.feeAtTier.toFixed(1)}% {achieved ? '(reached)' : `(-${milestone.feeDecreaseFromCurrent.toFixed(1)}%)`}
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+              <p className="text-center text-sm mt-10">
                 <span className="font-semibold">
                   {Math.max(0, nextMilestone.amount - clampedLifetime).toLocaleString('en-US')}
                 </span>


### PR DESCRIPTION
This pull request enhances the user experience and clarity of the seller fee discount system in the profile prize progress component. It introduces more detailed information about fee tiers, improves the display of coin amounts, and adds better milestone visualization for both desktop and mobile users.

**Profile Prize Progress Enhancements:**

- **Seller Fee Tier Details:**
  - Added logic to calculate and display the seller fee at each milestone tier, including how much the fee decreases as users progress. This is shown both on the progress bar and in milestone labels. [[1]](diffhunk://#diff-97e5bb11e3a62fd88b06e6df33fa9369e4acb35bb1b0b315a3fbb6bf49c6e2deR36-R45) [[2]](diffhunk://#diff-97e5bb11e3a62fd88b06e6df33fa9369e4acb35bb1b0b315a3fbb6bf49c6e2deR141-R170)
  - Updated milestone tooltips and labels to highlight current and potential fee reductions, making it clearer how leveling up benefits the user.

- **Coin Amount Formatting:**
  - Integrated the `roundDownCoinAmount` utility to standardize the display of coin amounts for both current and lifetime CadeCoins. [[1]](diffhunk://#diff-97e5bb11e3a62fd88b06e6df33fa9369e4acb35bb1b0b315a3fbb6bf49c6e2deL56-R74) [[2]](diffhunk://#diff-97e5bb11e3a62fd88b06e6df33fa9369e4acb35bb1b0b315a3fbb6bf49c6e2deR4)

- **UI Improvements:**
  - Enhanced milestone tick marks and labels on the progress bar to use the new tier fee data, improving accuracy and consistency. [[1]](diffhunk://#diff-97e5bb11e3a62fd88b06e6df33fa9369e4acb35bb1b0b315a3fbb6bf49c6e2deL78-R94) [[2]](diffhunk://#diff-97e5bb11e3a62fd88b06e6df33fa9369e4acb35bb1b0b315a3fbb6bf49c6e2deL103-R123)
  - Improved milestone label styling for better readability and added a more mobile-friendly milestone summary grid. [[1]](diffhunk://#diff-97e5bb11e3a62fd88b06e6df33fa9369e4acb35bb1b0b315a3fbb6bf49c6e2deL116-R132) [[2]](diffhunk://#diff-97e5bb11e3a62fd88b06e6df33fa9369e4acb35bb1b0b315a3fbb6bf49c6e2deR141-R170)

**How-to-Play Card Update:**

- **Clarified Discount Tier Mechanics:**
  - Updated the description in the relevant info card to explain how buying and selling more increases the user's discount tier, potentially reducing the seller fee from 4% to 2%.