### PR TITLE
Feat/price info estimator

### DIFF
--- a/src/integrations/api/client.ts
+++ b/src/integrations/api/client.ts
@@ -9,6 +9,7 @@ import {
   PrizeConfiguration,
   SellerShopResponse,
   SellerShopSummary,
+  PsaImportResult,
   SubmitPrizeRedemptionRequest,
 } from '@/types/prize';
 import { PromotedBetsResponse } from '@/types/promo';
@@ -1456,6 +1457,13 @@ export const prizeAPI = {
 
   rejectMyShopOffer: async (orderId: string) => {
     const response = await apiClient.patch(`/seller/prizes/offers/${orderId}/reject-offer`);
+    return response.data;
+  },
+
+  importPsaCert: async (certNumber: string): Promise<PsaImportResult> => {
+    const response = await apiClient.post('/seller/prizes/psa/import-cert', {
+      certNumber,
+    });
     return response.data;
   },
 

--- a/src/pages/SellerShopManage.tsx
+++ b/src/pages/SellerShopManage.tsx
@@ -27,7 +27,7 @@ import {
   HeadphonesIcon,
 } from 'lucide-react';
 import { useAuthContext } from '@/contexts/AuthContext';
-import { PrizeBrand, PrizeConfiguration } from '@/types/prize';
+import { PrizeBrand, PrizeConfiguration, type PsaImportResult } from '@/types/prize';
 import { CardFooter } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 import { Switch } from '@/components/ui/switch';
@@ -91,6 +91,9 @@ interface SellerPurchasedOrder {
 }
 
 export default function SellerShopManage() {
+  const PSA_RATE_LIMIT_MESSAGE = 'PSA is rate-limiting requests right now. Try again tomorrow.';
+  const PSA_RATE_LIMIT_UNTIL_KEY = 'sellerShopManage.psaRateLimitedUntil';
+
   const { session } = useAuthContext();
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -129,6 +132,9 @@ export default function SellerShopManage() {
   const [shopProfileImageFile, setShopProfileImageFile] = useState<File | null>(null);
   const shopProfileImageInputRef = React.useRef<HTMLInputElement>(null);
   const ordersRef = React.useRef<HTMLDivElement>(null);
+  const [psaCertNumber, setPsaCertNumber] = useState('');
+  const [psaImportResult, setPsaImportResult] = useState<PsaImportResult | null>(null);
+  const [psaRateLimitedUntil, setPsaRateLimitedUntil] = useState<number | null>(null);
 
   const [form, setForm] = useState({
     name: '',
@@ -144,6 +150,61 @@ export default function SellerShopManage() {
     isProOnly: false,
     profileFeatured: false,
   });
+
+  const normalizePsaBrand = (brand: string | null | undefined): PrizeBrand => {
+    const normalized = (brand || '').toLowerCase().trim();
+    if (normalized.includes('pokemon')) return 'pokemon';
+    if (normalized.includes('one piece')) return 'one_piece';
+    if (normalized.includes('sports')) return 'sports';
+    return 'other';
+  };
+
+  const getTomorrowStartMs = () => {
+    const tomorrow = new Date();
+    tomorrow.setHours(24, 0, 0, 0);
+    return tomorrow.getTime();
+  };
+
+  const clearPsaRateLimitCooldown = () => {
+    setPsaRateLimitedUntil(null);
+    localStorage.removeItem(PSA_RATE_LIMIT_UNTIL_KEY);
+  };
+
+  const activatePsaRateLimitCooldown = (untilIso?: string | null) => {
+    const parsed = untilIso ? Date.parse(untilIso) : NaN;
+    const fallback = getTomorrowStartMs();
+    const until = Number.isFinite(parsed) ? Math.max(parsed, Date.now()) : fallback;
+
+    setPsaRateLimitedUntil(until);
+    localStorage.setItem(PSA_RATE_LIMIT_UNTIL_KEY, String(until));
+  };
+
+  const isPsaRateLimited = Boolean(psaRateLimitedUntil && Date.now() < psaRateLimitedUntil);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(PSA_RATE_LIMIT_UNTIL_KEY);
+    if (!stored) {
+      return;
+    }
+
+    const until = Number(stored);
+    if (!Number.isFinite(until) || Date.now() >= until) {
+      localStorage.removeItem(PSA_RATE_LIMIT_UNTIL_KEY);
+      return;
+    }
+
+    setPsaRateLimitedUntil(until);
+  }, []);
+
+  useEffect(() => {
+    if (!psaRateLimitedUntil) {
+      return;
+    }
+
+    if (Date.now() >= psaRateLimitedUntil) {
+      clearPsaRateLimitCooldown();
+    }
+  }, [psaRateLimitedUntil]);
 
   const [selectedPurchasedOrder, setSelectedPurchasedOrder] = useState<SellerPurchasedOrder | null>(
     null
@@ -388,6 +449,68 @@ export default function SellerShopManage() {
     },
   });
 
+  const psaImportMutation = useMutation({
+    mutationFn: (certNumber: string) => api.prize.importPsaCert(certNumber),
+    onSuccess: (result: PsaImportResult) => {
+      if (result.rateLimitedUntilTomorrow) {
+        activatePsaRateLimitCooldown(result.rateLimitedUntil);
+        toast({
+          title: 'PSA import limited',
+          description: PSA_RATE_LIMIT_MESSAGE,
+          variant: 'destructive',
+        });
+      }
+
+      setPsaImportResult(result);
+
+      const importedImages = result.imageUrls.map((imageUrl, index) => ({
+        id: `psa-${result.certNumber}-${index}`,
+        imageUrl,
+        isNew: false,
+      }));
+
+      setForm(prev => ({
+        ...prev,
+        name: result.title || prev.name,
+        description: result.description || result.title || prev.description,
+        brand: normalizePsaBrand(result.brand),
+      }));
+
+      if (importedImages.length > 0) {
+        setItemImages(importedImages);
+        setCoverImageIndex(Math.min(result.coverImageIndex, importedImages.length - 1));
+      }
+
+      toast({
+        title: 'PSA import complete',
+        description: result.hasImages
+          ? 'Title, details, and images were filled from PSA.'
+          : 'Title and details were filled from PSA. No images were available for this cert.',
+      });
+    },
+    onError: (error: any) => {
+      const statusCode = error?.response?.status;
+      const errorCode = error?.response?.data?.errorCode;
+
+      if (statusCode === 429 || errorCode === 'PSA_RATE_LIMITED') {
+        activatePsaRateLimitCooldown(error?.response?.data?.rateLimitedUntil);
+        toast({
+          title: 'PSA import limited',
+          description: PSA_RATE_LIMIT_MESSAGE,
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      toast({
+        title: 'PSA import failed',
+        description:
+          error?.response?.data?.message || error?.message || 'Unable to import PSA cert data.',
+        variant: 'destructive',
+      });
+    },
+  });
+
   const counterOfferMutation = useMutation({
     mutationFn: (data: { orderId: string; counterOfferAmount: number; offerNotes?: string }) =>
       api.prize.counterMyShopOffer(data.orderId, data),
@@ -589,6 +712,7 @@ export default function SellerShopManage() {
 
   const handleCancelEdit = () => {
     setEditingItemId(null);
+    setPsaImportResult(null);
     setForm({
       name: '',
       description: '',
@@ -1108,6 +1232,104 @@ export default function SellerShopManage() {
                 </CardHeader>
                 <CardContent className="space-y-4">
                   <div className="grid gap-2">
+                    <Label>PSA Cert Number</Label>
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                      <Input
+                        placeholder="Enter PSA cert number"
+                        value={psaCertNumber}
+                        onChange={e => setPsaCertNumber(e.target.value)}
+                        disabled={isPsaRateLimited}
+                      />
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => psaImportMutation.mutate(psaCertNumber)}
+                        disabled={psaImportMutation.isPending || !psaCertNumber.trim() || isPsaRateLimited}
+                      >
+                        {psaImportMutation.isPending ? (
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        ) : null}
+                        Autofill from PSA
+                      </Button>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Pulls the title, grade, and available PSA images into the listing form.
+                    </p>
+                    {isPsaRateLimited && (
+                      <p className="text-xs text-destructive">{PSA_RATE_LIMIT_MESSAGE}</p>
+                    )}
+
+                    {psaImportResult && (
+                      <div className="rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-xs text-muted-foreground space-y-2">
+                        <div className="font-semibold text-foreground">PSA Import Summary</div>
+                        <div>
+                          Population ({psaImportResult.cardGrade ? `PSA ${psaImportResult.cardGrade}` : 'this grade'}):{' '}
+                          {psaImportResult.psaPopulation?.gradePopulation !== null &&
+                          psaImportResult.psaPopulation?.gradePopulation !== undefined
+                            ? new Intl.NumberFormat().format(psaImportResult.psaPopulation.gradePopulation)
+                            : 'N/A'}
+                        </div>
+                        <div>
+                          <a
+                            href={psaImportResult.psaCertUrl || `https://www.psacard.com/cert/${encodeURIComponent(psaImportResult.certNumber)}/psa`}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-primary underline underline-offset-2"
+                          >
+                            View on PSA
+                          </a>
+                        </div>
+
+                        <div className="pt-1">
+                          <div className="font-semibold text-foreground">Item Information</div>
+                          <div className="mt-1 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1">
+                            <div className="text-foreground">
+                              <span className="text-muted-foreground">Cert Number:</span>{' '}
+                              {psaImportResult.itemInformation?.certNumber || 'N/A'}
+                            </div>
+                            <div className="text-foreground">
+                              <span className="text-muted-foreground">Item Grade:</span>{' '}
+                              {psaImportResult.itemInformation?.itemGrade ?? 'N/A'}
+                            </div>
+                            <div className="text-foreground">
+                              <span className="text-muted-foreground">Brand/Title:</span>{' '}
+                              {psaImportResult.itemInformation?.brandTitle ?? 'N/A'}
+                            </div>
+                            <div className="text-foreground">
+                              <span className="text-muted-foreground">Subject:</span>{' '}
+                              {psaImportResult.itemInformation?.subject ?? 'N/A'}
+                            </div>
+                            <div className="text-foreground">
+                              <span className="text-muted-foreground">Variety/Pedigree:</span>{' '}
+                              {psaImportResult.itemInformation?.varietyPedigree ?? 'N/A'}
+                            </div>
+                            <div className="text-foreground">
+                              <span className="text-muted-foreground">Year:</span>{' '}
+                              {psaImportResult.itemInformation?.year ?? 'N/A'}
+                            </div>
+                            <div className="text-foreground">
+                              <span className="text-muted-foreground">Card Number:</span>{' '}
+                              {psaImportResult.itemInformation?.cardNumber ?? 'N/A'}
+                            </div>
+                            <div className="text-foreground">
+                              <span className="text-muted-foreground">Category:</span>{' '}
+                              {psaImportResult.itemInformation?.category ?? 'N/A'}
+                            </div>
+                            <div className="text-foreground">
+                              <span className="text-muted-foreground">Label Type:</span>{' '}
+                              {psaImportResult.itemInformation?.labelType ?? 'N/A'}
+                            </div>
+                            <div className="text-foreground">
+                              <span className="text-muted-foreground">Reverse Cert/Barcode:</span>{' '}
+                              {psaImportResult.itemInformation?.reverseCertBarcode ?? 'N/A'}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="grid gap-2">
                     <Label>Name *</Label>
                     <Input
                       placeholder="e.g., Charizard PSA 10"
@@ -1295,6 +1517,12 @@ export default function SellerShopManage() {
                     </p>
                   </div>
 
+                  {psaCertNumber.trim() && (
+                    <div className="rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-xs text-muted-foreground">
+                      PSA cert {psaCertNumber.trim()} is ready to import or update.
+                    </div>
+                  )}
+
                   {session?.isProSubscriber && (
                     <div className="flex items-center justify-between rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-3">
                       <div className="space-y-0.5">
@@ -1344,9 +1572,8 @@ export default function SellerShopManage() {
                       Drag to reorder photos. Use the star button to choose cover photo.
                     </p>
                     <p className="rounded-md border border-[#D4FF00]/40 bg-[#D4FF00]/10 px-3 py-2 text-xs font-semibold text-[#D4FF00]">
-                      Please lookup the cert number for your slab to see if there are high
-                      resolution photos of it. If so, right click images, save to downloads, and
-                      upload those photos here.
+                      You can import PSA cert details and images first, then make any manual edits
+                      before saving the listing.
                     </p>
                   </div>
 

--- a/src/types/prize.ts
+++ b/src/types/prize.ts
@@ -4,6 +4,45 @@
 
 export type PrizeBrand = 'pokemon' | 'one_piece' | 'sports' | 'other';
 
+export interface PsaImportResult {
+  certNumber: string;
+  title: string;
+  brand: string | null;
+  category: string | null;
+  year: string | null;
+  cardNumber: string | null;
+  subject: string | null;
+  variety: string | null;
+  gradeDescription: string | null;
+  cardGrade: string | null;
+  description: string | null;
+  imageUrls: string[];
+  coverImageIndex: number;
+  coverImageUrl: string | null;
+  hasImages: boolean;
+  psaSpecId: number | null;
+  psaPopulation: {
+    gradePopulation: number | null;
+  } | null;
+  rateLimitedUntilTomorrow: boolean;
+  rateLimitedUntil: string | null;
+  psaCertUrl: string;
+  itemInformation: {
+    certNumber: string;
+    itemGrade: string | null;
+    labelType: string | null;
+    fugitiveInkTechnology: string | null;
+    reverseCertBarcode: string | null;
+    year: string | null;
+    brandTitle: string | null;
+    subject: string | null;
+    cardNumber: string | null;
+    category: string | null;
+    varietyPedigree: string | null;
+  };
+  source: 'psa';
+}
+
 export interface ItemImage {
   id: string;
   imageUrl: string;


### PR DESCRIPTION
This pull request adds a new feature to the seller shop management page, allowing sellers to autofill prize listing details and images by importing PSA (Professional Sports Authenticator) cert numbers. It also introduces rate-limiting handling for PSA imports, UI feedback for import status, and updates to the form and user experience around PSA data. The most important changes are grouped below.

**PSA Import Feature Integration:**

* Added a new `PsaImportResult` type to `@/types/prize` to represent the data returned from a PSA cert import, including cert details, images, population data, and rate limit info.
* Implemented a new API client method `importPsaCert` in `src/integrations/api/client.ts` to call the backend endpoint for importing PSA cert data. [[1]](diffhunk://#diff-5da9525b80e737f8309b545d662efffd75ca1dfaa50ab3695364b081c8460173R12) [[2]](diffhunk://#diff-5da9525b80e737f8309b545d662efffd75ca1dfaa50ab3695364b081c8460173R1463-R1469)
* Integrated PSA cert import into `SellerShopManage.tsx` with a new UI section for entering a cert number, triggering the import, and displaying the imported data and images. [[1]](diffhunk://#diff-042ebde7a523c247c6136bf8aa66fd20e192937c8b3395b249a98f47a55bf3fbR1234-R1331) [[2]](diffhunk://#diff-042ebde7a523c247c6136bf8aa66fd20e192937c8b3395b249a98f47a55bf3fbR1520-R1525)
* Automatically fills out the listing form with PSA data and images if available, and provides user feedback via toasts and form updates.

**PSA Rate Limiting and UX Enhancements:**

* Added logic to handle PSA API rate limiting, including local storage of cooldowns, disabling the import button when rate-limited, and showing user-facing messages about rate limits. [[1]](diffhunk://#diff-042ebde7a523c247c6136bf8aa66fd20e192937c8b3395b249a98f47a55bf3fbR94-R96) [[2]](diffhunk://#diff-042ebde7a523c247c6136bf8aa66fd20e192937c8b3395b249a98f47a55bf3fbR135-R137) [[3]](diffhunk://#diff-042ebde7a523c247c6136bf8aa66fd20e192937c8b3395b249a98f47a55bf3fbR452-R513)
* Improved user guidance and messaging around PSA imports, replacing previous manual image upload instructions with new autofill instructions, and providing clear feedback for both success and error states.

**General Improvements:**

* Ensured PSA import state is reset when cancelling editing a listing.
* Added normalization logic for PSA brand names to match internal `PrizeBrand` types.

These changes collectively streamline the process for sellers to list PSA-graded items by reducing manual data entry and improving the reliability and clarity of the user experience.