### PR TITLE
add product type filtering to shop detail page

### DIFF
--- a/src/pages/ShopDetail.tsx
+++ b/src/pages/ShopDetail.tsx
@@ -53,6 +53,18 @@ export default function ShopDetail() {
   const brandFilterParam = searchParams.get('brand');
   const selectedBrands = brandFilterParam ? brandFilterParam.split(',') : [];
 
+  // Get product type filter from URL params (supports comma-separated values)
+  const categoryFilterParam = searchParams.get('category');
+  const validProductCategories = ['raw', 'slab', 'sealed', 'other'] as const;
+  const selectedProductCategories = categoryFilterParam
+    ? categoryFilterParam
+        .split(',')
+        .filter(
+          (category): category is (typeof validProductCategories)[number] =>
+            validProductCategories.includes(category as (typeof validProductCategories)[number])
+        )
+    : [];
+
   // Fetch seller shop and seller-specific inventory
   const { data: shopData, isLoading: isLoadingShop } = useQuery({
     queryKey: ['seller-shop-items', username],
@@ -145,6 +157,13 @@ export default function ShopDetail() {
   // Apply brand filter if any brands are selected
   if (selectedBrands.length > 0) {
     slabPrizes = slabPrizes.filter(prize => prize.brand && selectedBrands.includes(prize.brand));
+  }
+
+  // Apply product type filter if any categories are selected
+  if (selectedProductCategories.length > 0) {
+    slabPrizes = slabPrizes.filter(
+      prize => prize.category && selectedProductCategories.includes(prize.category)
+    );
   }
 
   // Apply search filter


### PR DESCRIPTION
This pull request adds support for filtering shop inventory by product category in the `ShopDetail` page. The main changes include parsing a new `category` filter from the URL, validating it, and applying it to the inventory list.

**Product Category Filtering:**

* Added parsing for a `category` URL parameter, supporting comma-separated values, and filtering to only allow valid product categories (`raw`, `slab`, `sealed`, `other`) in `ShopDetail.tsx`.
* Applied the selected product categories as an additional filter to the displayed inventory, so only items matching the chosen categories are shown.