### PR TITLE
update max image limit to use configurable constant

### DIFF
--- a/src/components/admin/PrizeConfiguration.tsx
+++ b/src/components/admin/PrizeConfiguration.tsx
@@ -34,6 +34,7 @@ import {
   Seller,
 } from '@/types/prize';
 import { ItemImageGallery, type ItemImageInput } from '@/components/items/ItemImageGallery';
+import { IMAGE_UPLOAD_CONFIG } from '@/utils/imageUploadConstants';
 import {
   Dialog,
   DialogContent,
@@ -1875,7 +1876,7 @@ export const PrizeConfiguration = () => {
                 onImagesChange={setItemImages}
                 onCoverIndexChange={setCoverImageIndex}
                 onError={setImageError}
-                maxImages={7}
+                maxImages={IMAGE_UPLOAD_CONFIG.ITEM_MAX_IMAGES}
                 disabled={isUploading || createMutation.isPending || updateMutation.isPending}
               />
               <p className="text-xs text-muted-foreground">

--- a/src/components/items/ItemImageGallery.tsx
+++ b/src/components/items/ItemImageGallery.tsx
@@ -155,7 +155,7 @@ export function ItemImageGallery({
   onImagesChange,
   onCoverIndexChange,
   onError,
-  maxImages = 7,
+  maxImages = IMAGE_UPLOAD_CONFIG.ITEM_MAX_IMAGES,
   disabled = false,
 }: ItemImageGalleryProps) {
   const [cropQueue, setCropQueue] = useState<File[]>([]);

--- a/src/pages/SellerShopManage.tsx
+++ b/src/pages/SellerShopManage.tsx
@@ -43,6 +43,7 @@ import { Badge } from '@/components/ui/badge';
 import { SellerOnboardingModal } from '@/components/seller/SellerOnboardingModal';
 import { SearchInput } from '@/components/ui/SearchInput';
 import { ItemImageGallery, type ItemImageInput } from '@/components/items/ItemImageGallery';
+import { IMAGE_UPLOAD_CONFIG } from '@/utils/imageUploadConstants';
 import { getThumbnailUrl } from '@/utils/helper';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 
@@ -1704,7 +1705,7 @@ export default function SellerShopManage() {
                       coverIndex={coverImageIndex}
                       onImagesChange={setItemImages}
                       onCoverIndexChange={setCoverImageIndex}
-                      maxImages={7}
+                      maxImages={IMAGE_UPLOAD_CONFIG.ITEM_MAX_IMAGES}
                       disabled={isUploading || createItem.isPending}
                     />
                     <p className="text-xs text-muted-foreground">

--- a/src/utils/imageUploadConstants.ts
+++ b/src/utils/imageUploadConstants.ts
@@ -25,7 +25,7 @@ export const IMAGE_UPLOAD_CONFIG = {
   PRIZE_DOUBLE_SLAB_ASPECT_RATIO: 16 / 13,
 
   /** Max number of item photos allowed for a single listing */
-  ITEM_MAX_IMAGES: 7,
+  ITEM_MAX_IMAGES: 6,
   
   /** Maximum width in pixels after resize */
   MAX_WIDTH: 1920,


### PR DESCRIPTION
This pull request standardizes the maximum number of images allowed for item uploads across the codebase by centralizing the configuration in the `IMAGE_UPLOAD_CONFIG` constant and updating all relevant usages. The maximum number of images per item is also changed from 7 to 6.

Configuration and consistency improvements:

* Changed the value of `ITEM_MAX_IMAGES` in `IMAGE_UPLOAD_CONFIG` from 7 to 6, reducing the allowed number of images per item.
* Updated all usages of the `maxImages` prop in `ItemImageGallery` and related components to reference `IMAGE_UPLOAD_CONFIG.ITEM_MAX_IMAGES` instead of hardcoding the value 7, ensuring consistency throughout the codebase. [[1]](diffhunk://#diff-7e16115de06ead60c674fba6b60369ab8a2d352d572ce96eb17e114d3d3a4c75L1878-R1879) [[2]](diffhunk://#diff-f6233f10061341cc4ea173510610db94224fe28ced407ca6ce0d61e7c64ef15cL158-R158) [[3]](diffhunk://#diff-042ebde7a523c247c6136bf8aa66fd20e192937c8b3395b249a98f47a55bf3fbL1707-R1708)

Code maintainability:

* Added imports for `IMAGE_UPLOAD_CONFIG` in files where the image limit is now referenced, improving maintainability and clarity. [[1]](diffhunk://#diff-7e16115de06ead60c674fba6b60369ab8a2d352d572ce96eb17e114d3d3a4c75R37) [[2]](diffhunk://#diff-042ebde7a523c247c6136bf8aa66fd20e192937c8b3395b249a98f47a55bf3fbR46)