### PR TITLE
refactor: update navigation and card descriptions for clarity and conciseness

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -165,7 +165,7 @@ export const Navigation = ({ onDashboardClick, searchValue, onSearchChange }: Na
     { label: 'Shop', icon: undefined, path: '/' },
     { label: 'Redeem', icon: undefined, path: '/redemptions' },
     { label: 'Leaderboard', icon: undefined, path: '/leaderboard' },
-    { label: 'Predictions', icon: undefined, path: '/predictions' },
+    // { label: 'Predictions', icon: undefined, path: '/predictions' },
     { label: 'How To Play', icon: undefined, path: '/how-to-play' },
     (session?.role === 'admin' || session?.role === 'creator') && {
       label: session?.role === 'admin' ? 'Admin Dashboard' : 'Creator Dashboard',

--- a/src/components/how-to-play/cardData.tsx
+++ b/src/components/how-to-play/cardData.tsx
@@ -12,7 +12,7 @@ export const infoCards: InfoCard[] = [
     trailWord: 'BUY',
     description: (
       <>
-        Buy cards on CardCade in an easier, friendlier, more transparent, more fun manner than anywhere else on the internet!
+        Buy trading cards in the easiest, friendliest, and cheapest manner on the internet.
       </>
     ),
   },
@@ -21,7 +21,7 @@ export const infoCards: InfoCard[] = [
     trailWord: 'SELL',
     description: (
       <>
-        List/sell cards on CardCade with lower fees, full security provisioning, and full support of our team.
+        Sell at the lowest fees around, with full security and our team's support.
       </>
     ),
   },
@@ -30,7 +30,7 @@ export const infoCards: InfoCard[] = [
     trailWord: 'FUN',
     description: (
       <>
-        Win prizes along the way by accumulating CadeCoins from buying, selling, and participating in predictions & games. The more you buy and sell, the higher your discount tier climbs. As you level up, your seller fee can drop from 4% to 2% so you keep more on every sale.
+        Earn CadeCoins (CCs) as you buy/sell/bid; CCs are redeemable for prizes and reduce seller fees.
       </>
     ),
   },


### PR DESCRIPTION
This pull request makes small updates to the navigation and the "How To Play" info cards. The "Predictions" navigation item has been commented out, and the info card descriptions have been rewritten for clarity and conciseness.

Navigation changes:
* Commented out the "Predictions" navigation item in `Navigation.tsx`, so it no longer appears in the app's main navigation.

Content updates to info cards:
* Updated the "BUY" card description to emphasize ease, friendliness, and low cost of buying trading cards.
* Updated the "SELL" card description to highlight lowest fees, security, and team support.
* Simplified the "FUN" card description to focus on earning CadeCoins, redeeming prizes, and reducing seller fees.