### PR TITLE
Increase featured items header size for better visibility

### DIFF
--- a/src/pages/Prizes.tsx
+++ b/src/pages/Prizes.tsx
@@ -404,7 +404,7 @@ export default function Prizes() {
             {featuredPrizes.length > 0 && (
               <>
                 {session && (
-                  <h2 className="text-2xl font-bold px-2">
+                  <h2 className="text-4xl font-bold px-2">
                     {featured.mode === 'auctions' ? 'Auctions:' : 'Featured Items:'}
                   </h2>
                 )}


### PR DESCRIPTION
This pull request makes a small visual adjustment to the `Prizes` page. The heading for featured prizes is now displayed in a larger font size for improved emphasis and readability.

* Increased the heading size from `text-2xl` to `text-4xl` for the featured prizes section in `Prizes.tsx`.