### PR TITLE
refactor: remove Google Analytics script from index.html and update init condition in analytics.ts

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,17 +29,6 @@
     <meta name="google-site-verification" content="XY_A9UqrbHzkJJis4c6D6WPXImWt8DMzd5cpobscCms" />
 
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-R75M7T2JSN"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-
-      gtag('config', 'G-R75M7T2JSN');
-    </script>
     <script>
       // iOS Safari drawer scroll fix
       // This prevents the vaul drawer library from locking the body scroll

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -3,8 +3,7 @@ export function initGoogleAnalytics(): void {
     return;
   }
 
-  const isProd = import.meta?.env?.VITE_BUGSNAG_SERVER === 'prod';
-  if (!isProd) {
+  if (window.location.hostname !== 'cardcade.fun') {
     return;
   }
 
@@ -39,8 +38,7 @@ export function initHotjar(): void {
     return;
   }
 
-  const isProd = import.meta?.env?.VITE_BUGSNAG_SERVER === 'prod';
-  if (!isProd) {
+  if (window.location.hostname !== 'cardcade.fun') {
     return;
   }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import './index.css';
 import '@solana/wallet-adapter-react-ui/styles.css';
 import { initGoogleAnalytics, initHotjar } from './lib/analytics';
 
-// initGoogleAnalytics();
+initGoogleAnalytics();
 initHotjar();
 
 createRoot(document.getElementById('root')!).render(<App />);


### PR DESCRIPTION
This pull request updates how analytics scripts are initialized and ensures they only run in the production environment. It removes the inline Google Analytics script from `index.html` and moves all analytics initialization to TypeScript, activating them only for the production domain (`cardcade.fun`). This helps prevent analytics from running in development or on non-production deployments.

Analytics initialization improvements:

* Removed the inline Google Analytics script from `index.html` to avoid duplicate or unintended tracking and to centralize analytics logic in the codebase.
* Updated `initGoogleAnalytics` and `initHotjar` in `src/lib/analytics.ts` to only initialize when the site is running on the production domain (`cardcade.fun`), rather than relying on an environment variable. [[1]](diffhunk://#diff-af25af6c1c85456cbce5a4eda14f0b3965aacdd964420dde9a08ee5c7c2674afL6-R6) [[2]](diffhunk://#diff-af25af6c1c85456cbce5a4eda14f0b3965aacdd964420dde9a08ee5c7c2674afL42-R41)
* Enabled the call to `initGoogleAnalytics()` in `src/main.tsx` so that analytics are initialized at app startup, but only in production.