### PR TITLE
implement eBay feature controls and settings management

### DIFF
--- a/src/components/admin/EbayDataPanel.tsx
+++ b/src/components/admin/EbayDataPanel.tsx
@@ -2,6 +2,12 @@ import { useState } from 'react';
 import { TabSwitch } from '@/components/navigation/TabSwitch';
 import { ReportedEbayListingsPanel } from './ReportedEbayListingsPanel';
 import { ManageItemDataPanel } from './ManageItemDataPanel';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/integrations/api/client';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { toast } from '@/hooks/use-toast';
 
 const EBAY_DATA_TABS = [
   { key: 'manage-item-data', label: 'Manage Item Data' },
@@ -10,9 +16,98 @@ const EBAY_DATA_TABS = [
 
 export const EbayDataPanel = () => {
   const [activeTab, setActiveTab] = useState('manage-item-data');
+  const queryClient = useQueryClient();
+
+  const { data: cardcadeSettings } = useQuery({
+    queryKey: ['cardcade-shop-settings'],
+    queryFn: () => api.prize.getShopSettings('cardcade'),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const socials = (cardcadeSettings?.socials ?? {}) as Record<string, string>;
+
+  const parseFlag = (value: unknown, fallback: boolean): boolean => {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (normalized === 'true') return true;
+      if (normalized === 'false') return false;
+    }
+
+    return fallback;
+  };
+
+  const ebaySoldAvgEnabled = parseFlag(socials._ff_ebaySoldAvg, true);
+  const ebayManualSyncEnabled = parseFlag(socials._ff_ebayManualSync, true);
+
+  const updateSettingsMutation = useMutation({
+    mutationFn: (nextSocials: Record<string, string>) =>
+      api.prize.updateShopSettings('cardcade', {
+        socials: nextSocials,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['cardcade-shop-settings'] });
+      toast({ title: 'Saved', description: 'eBay feature controls updated.' });
+    },
+    onError: () => {
+      toast({
+        title: 'Save failed',
+        description: 'Unable to update eBay feature controls right now.',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const setFlag = (key: '_ff_ebaySoldAvg' | '_ff_ebayManualSync', value: boolean) => {
+    const baseSocials = (cardcadeSettings?.socials ?? {}) as Record<string, string>;
+    const nextSocials: Record<string, string> = {
+      ...baseSocials,
+      [key]: String(value),
+    };
+
+    updateSettingsMutation.mutate(nextSocials);
+  };
 
   return (
     <div className="space-y-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">eBay Feature Controls</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between rounded-md border p-3">
+            <div className="space-y-1 pr-3">
+              <Label className="text-sm font-medium">Show eBay Sold Avg on Item Cards</Label>
+              <p className="text-xs text-muted-foreground">
+                Controls the public eBay sold average box shown on main shop item cards.
+              </p>
+            </div>
+            <Switch
+              checked={ebaySoldAvgEnabled}
+              onCheckedChange={(checked) => setFlag('_ff_ebaySoldAvg', checked)}
+              disabled={updateSettingsMutation.isPending}
+            />
+          </div>
+
+          <div className="flex items-center justify-between rounded-md border p-3">
+            <div className="space-y-1 pr-3">
+              <Label className="text-sm font-medium">Allow Manual Fetch Sold Data Now</Label>
+              <p className="text-xs text-muted-foreground">
+                Controls the admin-facing manual sync action for individual items.
+              </p>
+            </div>
+            <Switch
+              checked={ebayManualSyncEnabled}
+              onCheckedChange={(checked) => setFlag('_ff_ebayManualSync', checked)}
+              disabled={updateSettingsMutation.isPending}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
       <TabSwitch
         tabs={EBAY_DATA_TABS}
         activeTab={activeTab}

--- a/src/components/prizes/PrizeCard.tsx
+++ b/src/components/prizes/PrizeCard.tsx
@@ -425,6 +425,16 @@ export default function PrizeCard({
   }, [isProUser, prize.isProOnly, prize.proEarlyAccessUntil]);
   const isDisabled = isOutOfStock || isProLocked;
 
+  const ebayFeatureFlagsQuery = useQuery({
+    queryKey: ['ebay-feature-flags'],
+    queryFn: () => prizeAPI.getEbayFeatureFlags(),
+    staleTime: 1000 * 60 * 5,
+    retry: 1,
+  });
+
+  const ebaySoldAvgEnabled = ebayFeatureFlagsQuery.data?.ebaySoldAvgEnabled ?? true;
+  const ebayManualSyncEnabled = ebayFeatureFlagsQuery.data?.ebayManualSyncEnabled ?? true;
+
   // Early-access countdown: only for items with a timed window (not permanently pro-only)
   const earlyAccessDate = !prize.isProOnly ? prize.proEarlyAccessUntil : null;
   const { timeLeft: earlyAccessTimeLeft } = useCountdown(earlyAccessDate);
@@ -433,6 +443,7 @@ export default function PrizeCard({
   const marketSummaryQuery = useQuery({
     queryKey: ['ebay-market-summary', prize.id],
     queryFn: () => prizeAPI.getEbayMarketSummary(prize.id),
+    enabled: ebaySoldAvgEnabled || showMarketModal || (isAdminUser && ebayManualSyncEnabled),
     staleTime: 1000 * 60 * 5,
     retry: 1,
   });
@@ -721,45 +732,47 @@ export default function PrizeCard({
               {prize.amount.toLocaleString('en-US')} coins • ${(prize.amount / 50).toFixed(2)} USD
             </p>
           )}
-          <button
-            type="button"
-            className="w-full rounded-md border border-[#2A2F3A] bg-[#11151d] px-3 py-2 text-left transition-colors hover:border-[#7AFF14]/50"
-            onClick={e => {
-              e.stopPropagation();
-              setShowMarketModal(true);
-            }}
-          >
-            <div className="text-[10px] uppercase tracking-wide text-muted-foreground">eBay sold avg (latest 10)</div>
-            {marketSummaryQuery.isLoading ? (
-              <div className="mt-1 text-xs text-muted-foreground">Loading market data...</div>
-            ) : latestAvg !== null ? (
-              <div className="mt-1 flex items-center justify-between">
-                <span className="text-sm font-semibold text-[#7AFF14]">${latestAvg.toFixed(2)}</span>
-                <span
-                  className={cn(
-                    'text-xs font-semibold',
-                    latestPercentDiff === null
-                      ? 'text-muted-foreground'
-                      : latestPercentDiff >= 0
-                        ? 'text-orange-400'
-                        : 'text-emerald-400'
-                  )}
-                >
-                  {latestPercentDiff === null
-                    ? 'n/a'
-                    : `${latestPercentDiff >= 0 ? '+' : ''}${latestPercentDiff.toFixed(2)}%`}
-                </span>
+          {ebaySoldAvgEnabled && (
+            <button
+              type="button"
+              className="w-full rounded-md border border-[#2A2F3A] bg-[#11151d] px-3 py-2 text-left transition-colors hover:border-[#7AFF14]/50"
+              onClick={e => {
+                e.stopPropagation();
+                setShowMarketModal(true);
+              }}
+            >
+              <div className="text-[10px] uppercase tracking-wide text-muted-foreground">eBay sold avg (latest 10)</div>
+              {marketSummaryQuery.isLoading ? (
+                <div className="mt-1 text-xs text-muted-foreground">Loading market data...</div>
+              ) : latestAvg !== null ? (
+                <div className="mt-1 flex items-center justify-between">
+                  <span className="text-sm font-semibold text-[#7AFF14]">${latestAvg.toFixed(2)}</span>
+                  <span
+                    className={cn(
+                      'text-xs font-semibold',
+                      latestPercentDiff === null
+                        ? 'text-muted-foreground'
+                        : latestPercentDiff >= 0
+                          ? 'text-orange-400'
+                          : 'text-emerald-400'
+                    )}
+                  >
+                    {latestPercentDiff === null
+                      ? 'n/a'
+                      : `${latestPercentDiff >= 0 ? '+' : ''}${latestPercentDiff.toFixed(2)}%`}
+                  </span>
+                </div>
+              ) : (
+                <div className="mt-1 text-xs text-muted-foreground">0 sold listings</div>
+              )}
+              <div className="mt-1 text-[10px] text-muted-foreground">
+                {cardLastCalculated
+                  ? `Updated ${new Date(cardLastCalculated).toLocaleString()}`
+                  : ''}
               </div>
-            ) : (
-              <div className="mt-1 text-xs text-muted-foreground">0 sold listings</div>
-            )}
-            <div className="mt-1 text-[10px] text-muted-foreground">
-              {cardLastCalculated
-                ? `Updated ${new Date(cardLastCalculated).toLocaleString()}`
-                : ''}
-            </div>
-          </button>
-          {isAdminUser && (
+            </button>
+          )}
+          {isAdminUser && ebayManualSyncEnabled && (
             <Button
               type="button"
               variant="outline"
@@ -998,45 +1011,47 @@ export default function PrizeCard({
             )}
           </div>
 
-          <button
-            type="button"
-            className="mt-1 rounded-md border border-[#2A2F3A] bg-[#11151d] px-2.5 py-2 text-left transition-colors hover:border-[#7AFF14]/50"
-            onClick={e => {
-              e.stopPropagation();
-              setShowMarketModal(true);
-            }}
-          >
-            <div className="text-[10px] uppercase tracking-wide text-muted-foreground">eBay sold avg (latest 10)</div>
-            {marketSummaryQuery.isLoading ? (
-              <div className="mt-1 text-[11px] text-muted-foreground">Loading market data...</div>
-            ) : latestAvg !== null ? (
-              <div className="mt-1 flex items-center justify-between">
-                <span className="text-sm font-semibold text-[#7AFF14]">${latestAvg.toFixed(2)}</span>
-                <span
-                  className={cn(
-                    'text-[11px] font-semibold',
-                    latestPercentDiff === null
-                      ? 'text-muted-foreground'
-                      : latestPercentDiff >= 0
-                        ? 'text-orange-400'
-                        : 'text-emerald-400'
-                  )}
-                >
-                  {latestPercentDiff === null
-                    ? 'n/a'
-                    : `${latestPercentDiff >= 0 ? '+' : ''}${latestPercentDiff.toFixed(2)}%`}
-                </span>
+          {ebaySoldAvgEnabled && (
+            <button
+              type="button"
+              className="mt-1 rounded-md border border-[#2A2F3A] bg-[#11151d] px-2.5 py-2 text-left transition-colors hover:border-[#7AFF14]/50"
+              onClick={e => {
+                e.stopPropagation();
+                setShowMarketModal(true);
+              }}
+            >
+              <div className="text-[10px] uppercase tracking-wide text-muted-foreground">eBay sold avg (latest 10)</div>
+              {marketSummaryQuery.isLoading ? (
+                <div className="mt-1 text-[11px] text-muted-foreground">Loading market data...</div>
+              ) : latestAvg !== null ? (
+                <div className="mt-1 flex items-center justify-between">
+                  <span className="text-sm font-semibold text-[#7AFF14]">${latestAvg.toFixed(2)}</span>
+                  <span
+                    className={cn(
+                      'text-[11px] font-semibold',
+                      latestPercentDiff === null
+                        ? 'text-muted-foreground'
+                        : latestPercentDiff >= 0
+                          ? 'text-orange-400'
+                          : 'text-emerald-400'
+                    )}
+                  >
+                    {latestPercentDiff === null
+                      ? 'n/a'
+                      : `${latestPercentDiff >= 0 ? '+' : ''}${latestPercentDiff.toFixed(2)}%`}
+                  </span>
+                </div>
+              ) : (
+                <div className="mt-1 text-[11px] text-muted-foreground">0 sold listings</div>
+              )}
+              <div className="mt-1 text-[10px] text-muted-foreground">
+                {cardLastCalculated
+                  ? `Updated ${new Date(cardLastCalculated).toLocaleString()}`
+                  : ''}
               </div>
-            ) : (
-              <div className="mt-1 text-[11px] text-muted-foreground">0 sold listings</div>
-            )}
-            <div className="mt-1 text-[10px] text-muted-foreground">
-              {cardLastCalculated
-                ? `Updated ${new Date(cardLastCalculated).toLocaleString()}`
-                : ''}
-            </div>
-          </button>
-          {isAdminUser && (
+            </button>
+          )}
+          {isAdminUser && ebayManualSyncEnabled && (
             <Button
               type="button"
               variant="outline"
@@ -1338,7 +1353,7 @@ export default function PrizeCard({
                       </button>
                     ))}
                   </div>
-                  {isAdminUser && (
+                  {isAdminUser && ebayManualSyncEnabled && (
                     <Button
                       type="button"
                       variant="outline"

--- a/src/integrations/api/client.ts
+++ b/src/integrations/api/client.ts
@@ -1586,6 +1586,14 @@ export const prizeAPI = {
     return response.data;
   },
 
+  getEbayFeatureFlags: async (): Promise<{
+    ebaySoldAvgEnabled: boolean;
+    ebayManualSyncEnabled: boolean;
+  }> => {
+    const response = await apiClient.get('/prizes/ebay-feature-flags');
+    return response.data;
+  },
+
   getEbayMarketHistory: async (id: string, limit: number = 120): Promise<EbayMarketHistory> => {
     const response = await apiClient.get(`/prizes/shop-items/${id}/ebay-market-history`, {
       params: { limit },


### PR DESCRIPTION
This pull request introduces feature flag controls for eBay-related features, allowing admins to enable or disable the display of eBay sold average data and manual eBay data syncs. These controls are surfaced in the admin panel and respected throughout the user interface, ensuring that both public and admin-only eBay features can be toggled dynamically without code changes. The implementation includes new API integration for fetching these feature flags and updates to UI logic based on their state.

**Admin Panel Enhancements:**
- Added a new "eBay Feature Controls" card to the `EbayDataPanel` admin component, allowing toggling of "Show eBay Sold Avg on Item Cards" and "Allow Manual Fetch Sold Data Now" via switches. These controls update the backend and provide feedback via toasts.
- Utilized React Query to fetch and mutate shop settings, with logic to parse and update feature flag values in the settings' `socials` object.

**API Integration:**
- Added a new `getEbayFeatureFlags` method to `prizeAPI`, which fetches the current state of the eBay feature flags from the backend.

**Prize Card Behavior Changes:**
- Updated `PrizeCard` to query the new eBay feature flags and conditionally enable/disable the display of eBay sold average data and the admin manual sync button based on these flags. [[1]](diffhunk://#diff-44fd0eabc77e9f7b36ff98c9e4a586a31b0d48cc3fbd5918bbe0dd10f0eeffaeR428-R437) [[2]](diffhunk://#diff-44fd0eabc77e9f7b36ff98c9e4a586a31b0d48cc3fbd5918bbe0dd10f0eeffaeR446)
- Adjusted the logic for rendering eBay sold average UI elements and admin controls to respect the current flag state, ensuring that users and admins only see options appropriate to the current configuration. [[1]](diffhunk://#diff-44fd0eabc77e9f7b36ff98c9e4a586a31b0d48cc3fbd5918bbe0dd10f0eeffaeR735) [[2]](diffhunk://#diff-44fd0eabc77e9f7b36ff98c9e4a586a31b0d48cc3fbd5918bbe0dd10f0eeffaeL762-R775) [[3]](diffhunk://#diff-44fd0eabc77e9f7b36ff98c9e4a586a31b0d48cc3fbd5918bbe0dd10f0eeffaeR1014) [[4]](diffhunk://#diff-44fd0eabc77e9f7b36ff98c9e4a586a31b0d48cc3fbd5918bbe0dd10f0eeffaeL1039-R1054) [[5]](diffhunk://#diff-44fd0eabc77e9f7b36ff98c9e4a586a31b0d48cc3fbd5918bbe0dd10f0eeffaeL1341-R1356)