### PR TITLE
Add admin-only eBay sold avg flag

### DIFF
--- a/src/components/admin/EbayDataPanel.tsx
+++ b/src/components/admin/EbayDataPanel.tsx
@@ -41,6 +41,7 @@ export const EbayDataPanel = () => {
   };
 
   const ebaySoldAvgEnabled = parseFlag(socials._ff_ebaySoldAvg, true);
+  const ebaySoldAvgAdminOnly = parseFlag(socials._ff_ebaySoldAvgAdminOnly, false);
   const ebayManualSyncEnabled = parseFlag(socials._ff_ebayManualSync, true);
 
   const updateSettingsMutation = useMutation({
@@ -50,6 +51,7 @@ export const EbayDataPanel = () => {
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cardcade-shop-settings'] });
+      queryClient.invalidateQueries({ queryKey: ['ebay-feature-flags'] });
       toast({ title: 'Saved', description: 'eBay feature controls updated.' });
     },
     onError: () => {
@@ -61,7 +63,7 @@ export const EbayDataPanel = () => {
     },
   });
 
-  const setFlag = (key: '_ff_ebaySoldAvg' | '_ff_ebayManualSync', value: boolean) => {
+  const setFlag = (key: '_ff_ebaySoldAvg' | '_ff_ebaySoldAvgAdminOnly' | '_ff_ebayManualSync', value: boolean) => {
     const baseSocials = (cardcadeSettings?.socials ?? {}) as Record<string, string>;
     const nextSocials: Record<string, string> = {
       ...baseSocials,
@@ -88,6 +90,20 @@ export const EbayDataPanel = () => {
             <Switch
               checked={ebaySoldAvgEnabled}
               onCheckedChange={(checked) => setFlag('_ff_ebaySoldAvg', checked)}
+              disabled={updateSettingsMutation.isPending}
+            />
+          </div>
+
+          <div className="flex items-center justify-between rounded-md border p-3">
+            <div className="space-y-1 pr-3">
+              <Label className="text-sm font-medium">Admin-Only eBay Sold Avg Visibility</Label>
+              <p className="text-xs text-muted-foreground">
+                When enabled, only admins can see the eBay sold average on item cards (requires main toggle to be ON).
+              </p>
+            </div>
+            <Switch
+              checked={ebaySoldAvgAdminOnly}
+              onCheckedChange={(checked) => setFlag('_ff_ebaySoldAvgAdminOnly', checked)}
               disabled={updateSettingsMutation.isPending}
             />
           </div>

--- a/src/components/prizes/PrizeCard.tsx
+++ b/src/components/prizes/PrizeCard.tsx
@@ -433,7 +433,14 @@ export default function PrizeCard({
   });
 
   const ebaySoldAvgEnabled = ebayFeatureFlagsQuery.data?.ebaySoldAvgEnabled ?? true;
+  const ebaySoldAvgAdminOnly = ebayFeatureFlagsQuery.data?.ebaySoldAvgAdminOnly ?? false;
   const ebayManualSyncEnabled = ebayFeatureFlagsQuery.data?.ebayManualSyncEnabled ?? true;
+
+  // Determine if current user should see the eBay sold avg
+  // Show if: (public mode enabled) OR (admin-only mode enabled AND user is admin)
+  const shouldShowEbaySoldAvg = 
+    (ebaySoldAvgEnabled && !ebaySoldAvgAdminOnly) ||
+    (ebaySoldAvgAdminOnly && isAdminUser);
 
   // Early-access countdown: only for items with a timed window (not permanently pro-only)
   const earlyAccessDate = !prize.isProOnly ? prize.proEarlyAccessUntil : null;
@@ -443,7 +450,7 @@ export default function PrizeCard({
   const marketSummaryQuery = useQuery({
     queryKey: ['ebay-market-summary', prize.id],
     queryFn: () => prizeAPI.getEbayMarketSummary(prize.id),
-    enabled: ebaySoldAvgEnabled || showMarketModal || (isAdminUser && ebayManualSyncEnabled),
+    enabled: shouldShowEbaySoldAvg || showMarketModal || (isAdminUser && ebayManualSyncEnabled),
     staleTime: 1000 * 60 * 5,
     retry: 1,
   });
@@ -732,7 +739,7 @@ export default function PrizeCard({
               {prize.amount.toLocaleString('en-US')} coins • ${(prize.amount / 50).toFixed(2)} USD
             </p>
           )}
-          {ebaySoldAvgEnabled && (
+          {shouldShowEbaySoldAvg && (
             <button
               type="button"
               className="w-full rounded-md border border-[#2A2F3A] bg-[#11151d] px-3 py-2 text-left transition-colors hover:border-[#7AFF14]/50"
@@ -1011,7 +1018,7 @@ export default function PrizeCard({
             )}
           </div>
 
-          {ebaySoldAvgEnabled && (
+          {shouldShowEbaySoldAvg && (
             <button
               type="button"
               className="mt-1 rounded-md border border-[#2A2F3A] bg-[#11151d] px-2.5 py-2 text-left transition-colors hover:border-[#7AFF14]/50"

--- a/src/integrations/api/client.ts
+++ b/src/integrations/api/client.ts
@@ -1588,6 +1588,7 @@ export const prizeAPI = {
 
   getEbayFeatureFlags: async (): Promise<{
     ebaySoldAvgEnabled: boolean;
+    ebaySoldAvgAdminOnly: boolean;
     ebayManualSyncEnabled: boolean;
   }> => {
     const response = await apiClient.get('/prizes/ebay-feature-flags');


### PR DESCRIPTION
Introduce a new feature flag to restrict eBay sold average visibility to admins. Adds _ff_ebaySoldAvgAdminOnly to settings and UI: new toggle in the admin EbayDataPanel, includes the flag in setFlag typing and triggers invalidation of the 'ebay-feature-flags' query on save. PrizeCard now reads the flag from ebayFeatureFlagsQuery, computes shouldShowEbaySoldAvg (public vs admin-only + admin check), and uses it to gate fetching and rendering of eBay sold-average info. API client type for getEbayFeatureFlags updated to include ebaySoldAvgAdminOnly (defaults to false).