### PR TITLE
Add info banners to Leaderboard and Redemptions, update eBay button styles

### DIFF
--- a/src/components/prizes/AuctionCard.tsx
+++ b/src/components/prizes/AuctionCard.tsx
@@ -139,11 +139,6 @@ export default function AuctionCard({ prize }: AuctionCardProps) {
     ? ebaySoldAvgEnabled
     : (ebaySoldAvgEnabled && !ebaySoldAvgAdminOnly);
 
-  // Determine if actual eBay data should be displayed (vs "Coming Soon")
-  const canShowEbayData = isAdminUser
-    ? true
-    : (prize.showEbayAvgPublicly ?? false);
-
   // eBay market data
   const marketSummaryQuery = useQuery({
     queryKey: ['ebay-market-summary', prize.id],
@@ -152,6 +147,13 @@ export default function AuctionCard({ prize }: AuctionCardProps) {
     staleTime: 1000 * 60 * 5,
     retry: 1,
   });
+
+  // Determine if actual eBay data should be displayed (vs "Coming Soon")
+  // Check both configuration AND if there's actual data available
+  const canShowEbayData = isAdminUser
+    ? true
+    : (prize.showEbayAvgPublicly ?? false) && 
+      (marketSummaryQuery.data?.totalValidSoldCount ?? 0) > 0;
 
   const marketHistoryQuery = useQuery({
     queryKey: ['ebay-market-history', prize.id],
@@ -538,7 +540,7 @@ export default function AuctionCard({ prize }: AuctionCardProps) {
 
       <CardContent className="flex-1 flex flex-col gap-2 p-4">
         <div className="flex items-start justify-between gap-2">
-          <h3 className="font-semibold text-base leading-tight line-clamp-2">{prize.name}</h3>
+          <h3 className="font-semibold text-base leading-tight line-clamp-2 min-h-[40px]">{prize.name}</h3>
         </div>
 
 

--- a/src/components/prizes/AuctionCard.tsx
+++ b/src/components/prizes/AuctionCard.tsx
@@ -149,11 +149,10 @@ export default function AuctionCard({ prize }: AuctionCardProps) {
   });
 
   // Determine if actual eBay data should be displayed (vs "Coming Soon")
-  // Check both configuration AND if there's actual data available
-  const canShowEbayData = isAdminUser
-    ? true
-    : (prize.showEbayAvgPublicly ?? false) && 
-      (marketSummaryQuery.data?.totalValidSoldCount ?? 0) > 0;
+  // "Hide eBay avg" overrides everything (even for admins)
+  const canShowEbayData = (prize.showEbayAvgPublicly ?? false) && (
+    isAdminUser || (marketSummaryQuery.data?.totalValidSoldCount ?? 0) > 0
+  );
 
   const marketHistoryQuery = useQuery({
     queryKey: ['ebay-market-history', prize.id],

--- a/src/components/prizes/PrizeCard.tsx
+++ b/src/components/prizes/PrizeCard.tsx
@@ -397,11 +397,6 @@ export default function PrizeCard({
     ? ebaySoldAvgEnabled
     : (ebaySoldAvgEnabled && !ebaySoldAvgAdminOnly);
 
-  // Determine if actual eBay data should be displayed (vs "Coming Soon")
-  const canShowEbayData = isAdminUser
-    ? true
-    : (prize.showEbayAvgPublicly ?? false);
-
   // Early-access countdown: only for items with a timed window (not permanently pro-only)
   const earlyAccessDate = !prize.isProOnly ? prize.proEarlyAccessUntil : null;
   const { timeLeft: earlyAccessTimeLeft } = useCountdown(earlyAccessDate);
@@ -424,6 +419,13 @@ export default function PrizeCard({
   });
 
   const marketSummary = marketSummaryQuery.data;
+
+  // Determine if actual eBay data should be displayed (vs "Coming Soon")
+  // Check both configuration AND if there's actual data available
+  const canShowEbayData = isAdminUser
+    ? true
+    : (prize.showEbayAvgPublicly ?? false) && 
+      (marketSummaryQuery.data?.totalValidSoldCount ?? 0) > 0;
 
   const handleManualMarketSync = async () => {
     if (!isAdminUser) {
@@ -803,7 +805,7 @@ export default function PrizeCard({
 
         <CardContent className="p-3 flex-1 flex flex-col gap-1.5">
           {/* Prize Name */}
-          <h3 className="font-semibold text-sm line-clamp-2 leading-tight">{prize.name}</h3>
+          <h3 className="font-semibold text-sm line-clamp-2 leading-tight min-h-[38px]">{prize.name}</h3>
 
           {/* Description */}
           {prize.description && (

--- a/src/components/prizes/PrizeCard.tsx
+++ b/src/components/prizes/PrizeCard.tsx
@@ -421,11 +421,10 @@ export default function PrizeCard({
   const marketSummary = marketSummaryQuery.data;
 
   // Determine if actual eBay data should be displayed (vs "Coming Soon")
-  // Check both configuration AND if there's actual data available
-  const canShowEbayData = isAdminUser
-    ? true
-    : (prize.showEbayAvgPublicly ?? false) && 
-      (marketSummaryQuery.data?.totalValidSoldCount ?? 0) > 0;
+  // "Hide eBay avg" overrides everything (even for admins)
+  const canShowEbayData = (prize.showEbayAvgPublicly ?? false) && (
+    isAdminUser || (marketSummaryQuery.data?.totalValidSoldCount ?? 0) > 0
+  );
 
   const handleManualMarketSync = async () => {
     if (!isAdminUser) {


### PR DESCRIPTION
This pull request updates the logic for displaying eBay market data on prize cards and improves the visual consistency of card titles. The main focus is to ensure that eBay data is only shown when allowed by both admin status and the availability of valid data, and to enforce a minimum height for prize names to improve UI alignment.

**eBay Data Display Logic Updates:**

* The logic for `canShowEbayData` in both `AuctionCard.tsx` and `PrizeCard.tsx` was changed to only show eBay data if the "show eBay avg" flag is enabled and either the user is an admin or there is at least one valid sold item in the market summary. This also ensures that "Hide eBay avg" overrides all other conditions, including admin status. [[1]](diffhunk://#diff-a7edae5a8add6bf66da1fbfcef51b66fcb5768ae984c559ec4ef9be8307faf7dL142-L146) [[2]](diffhunk://#diff-a7edae5a8add6bf66da1fbfcef51b66fcb5768ae984c559ec4ef9be8307faf7dR151-R156) [[3]](diffhunk://#diff-44fd0eabc77e9f7b36ff98c9e4a586a31b0d48cc3fbd5918bbe0dd10f0eeffaeL400-L404) [[4]](diffhunk://#diff-44fd0eabc77e9f7b36ff98c9e4a586a31b0d48cc3fbd5918bbe0dd10f0eeffaeR423-R428)

**UI Improvements:**

* A minimum height was added to the prize name headings in both `AuctionCard.tsx` and `PrizeCard.tsx` to ensure consistent card layouts, even when prize names are short. [[1]](diffhunk://#diff-a7edae5a8add6bf66da1fbfcef51b66fcb5768ae984c559ec4ef9be8307faf7dL541-R542) [[2]](diffhunk://#diff-44fd0eabc77e9f7b36ff98c9e4a586a31b0d48cc3fbd5918bbe0dd10f0eeffaeL806-R807)