### PR TITLE
fix: update leaderboard and redemption messaging for clarity and engagement

### DIFF
--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -46,7 +46,7 @@ const Leaderboard = () => {
               </h3>
               <div className="space-y-2 text-sm text-white/90">
                 <p>
-                  The leaderboard shows the top players ranked by current CadeCoins balance.
+                  The leaderboard shows the top CadeCoin earners, by:
                 </p>
                 <ul className="space-y-1 ml-4">
                   <li className="flex items-start gap-2">
@@ -69,7 +69,7 @@ const Leaderboard = () => {
                     className="underline hover:no-underline transition-all"
                     style={{ color: 'var(--electric-lime)', textShadow: '0 0 5px rgba(189, 255, 0, 0.3)' }}
                   >
-                    making purchases
+                    buying
                   </Link>
                   ,{' '}
                   <Link 
@@ -77,7 +77,7 @@ const Leaderboard = () => {
                     className="underline hover:no-underline transition-all"
                     style={{ color: 'var(--electric-lime)', textShadow: '0 0 5px rgba(189, 255, 0, 0.3)' }}
                   >
-                    selling items
+                    selling
                   </Link>
                   , and spinning the{' '}
                   <Link 
@@ -87,7 +87,15 @@ const Leaderboard = () => {
                   >
                     daily spin
                   </Link>
-                  !
+                  ! Then go over to{' '}
+                  <Link 
+                    to="/redemptions" 
+                    className="underline hover:no-underline transition-all"
+                    style={{ color: 'var(--electric-lime)', textShadow: '0 0 5px rgba(189, 255, 0, 0.3)' }}
+                  >
+                    Prizes
+                  </Link>
+                  {' '}to redeem! We also do a monthly giveaway for the highest coin earner of the month
                 </p>
               </div>
             </div>

--- a/src/pages/Redemptions.tsx
+++ b/src/pages/Redemptions.tsx
@@ -13,7 +13,6 @@ import {
   Prize as PrizeDisplay,
 } from '@/components/prizes/PrizesByCategory';
 import PrizeCheckoutModal from '@/components/prizes/PrizeCheckoutModal';
-import { PrizeBrand } from '@/types/prize';
 import { resolvePrizeImages } from '@/components/prizes/prizeImageUtils';
 
 export default function Redemptions() {
@@ -26,8 +25,7 @@ export default function Redemptions() {
     shippingCostUsd?: number;
     isInPerson?: boolean;
   } | null>(null);
-  const [searchParams, setSearchParams] = useSearchParams();
-  const selectedBrand = (searchParams.get('brand')?.split(',')[0] as PrizeBrand) ?? null;
+  const [searchParams] = useSearchParams();
 
   const userCadeCoins = session?.walletBalanceCadeCoin || 0;
 
@@ -163,10 +161,6 @@ export default function Redemptions() {
     }
   }, [tiers]);
 
-  const displayPrizes = selectedBrand
-    ? allPrizes.filter(prize => prize.brand === selectedBrand)
-    : allPrizes;
-
   return (
     <MainLayout>
       {/* Info Banner */}
@@ -182,12 +176,10 @@ export default function Redemptions() {
               <h3 className="text-lg font-semibold text-white">How Prizes Work</h3>
               <div className="space-y-2 text-sm text-[#FFFFFFBF]">
                 <p>
-                  You've earned CadeCoins by playing! Now redeem them for sealed wax and trading
-                  card products.
+                  Congrats! You've earned Cadecoins.
                 </p>
                 <p>
-                  You can pay with 100% CadeCoins, 100% USD, or any mix of both. All items ship
-                  directly to you.
+                  Redeem them here for cards and sealed product, and we'll get them shipped out STAT!
                 </p>
               </div>
               {session && (
@@ -195,7 +187,7 @@ export default function Redemptions() {
                   <div className="flex items-center gap-2 text-sm">
                     <span className="text-[#FFFFFFBF]">Your Balance:</span>
                     <span className="font-bold text-primary">
-                      {userCadeCoins.toLocaleString()} CadeCoins
+                      {Math.floor(userCadeCoins).toLocaleString()} CadeCoins
                     </span>
                     <span className="text-green-500 font-semibold">
                       = ${(userCadeCoins / 50).toFixed(2)} USD
@@ -216,21 +208,16 @@ export default function Redemptions() {
         </Card>
       ) : (
         <>
-          {displayPrizes.length === 0 && selectedBrand === null ? (
+          {allPrizes.length === 0 ? (
             <div className="text-center py-12">
               <AlertCircle className="w-12 h-12 mx-auto text-muted-foreground mb-4" />
               <p className="text-muted-foreground">Coming soon!</p>
             </div>
           ) : (
             <PrizesByCategory
-              prizes={displayPrizes}
+              prizes={allPrizes}
               cardVariant="redemption"
-              selectedBrand={selectedBrand}
-              onBrandChange={brand => {
-                const p = new URLSearchParams(searchParams);
-                brand ? p.set('brand', brand) : p.delete('brand');
-                setSearchParams(p);
-              }}
+              showFilters={false}
               onPrizeClick={prize =>
                 setSelectedPrizeForCheckout({
                   id: prize.id,


### PR DESCRIPTION
This pull request updates the `Leaderboard` and `Redemptions` pages to improve user clarity and streamline the redemption experience. The main changes include rewording leaderboard descriptions, simplifying the redemption flow by removing brand filtering, and updating prize redemption instructions.

**Leaderboard page improvements:**
* Clarified the leaderboard description to emphasize top CadeCoin earners and simplified the activity descriptions from "making purchases" and "selling items" to "buying" and "selling". [[1]](diffhunk://#diff-c39a19a3d08c7cc550d8ec0a9d952bb6c3809aefb49b4312fbffdb5bf9c5119dL49-R49) [[2]](diffhunk://#diff-c39a19a3d08c7cc550d8ec0a9d952bb6c3809aefb49b4312fbffdb5bf9c5119dL72-R80)
* Added a call-to-action linking users to the Prizes page and mentioned the monthly giveaway for the top coin earner.

**Redemptions page simplification and copy updates:**
* Removed the brand filter and related logic from the redemptions page, so all prizes are now shown without filtering by brand. [[1]](diffhunk://#diff-d19b9e19e9527c673c2a3e9240700e67b4b2bfab94dfee34217f436b0ab877b7L16) [[2]](diffhunk://#diff-d19b9e19e9527c673c2a3e9240700e67b4b2bfab94dfee34217f436b0ab877b7L29-R28) [[3]](diffhunk://#diff-d19b9e19e9527c673c2a3e9240700e67b4b2bfab94dfee34217f436b0ab877b7L166-L169) [[4]](diffhunk://#diff-d19b9e19e9527c673c2a3e9240700e67b4b2bfab94dfee34217f436b0ab877b7L219-R220)
* Updated instructional copy to be more concise and upbeat, and clarified the redemption and shipping process.
* Ensured the user's CadeCoin balance is displayed as a whole number for clarity.