### PR TITLE
Improve messaging clarity and manage eBay button visibility

### DIFF
--- a/src/components/admin/EbayDataPanel.tsx
+++ b/src/components/admin/EbayDataPanel.tsx
@@ -46,6 +46,7 @@ export const EbayDataPanel = () => {
   const ebaySoldAvgEnabled = parseFlag(socials._ff_ebaySoldAvg, true);
   const ebaySoldAvgAdminOnly = parseFlag(socials._ff_ebaySoldAvgAdminOnly, false);
   const ebayManualSyncEnabled = parseFlag(socials._ff_ebayManualSync, true);
+  const ebayItemCardButtonPublic = parseFlag(socials._ff_ebayItemCardButtonPublic, false);
 
   const updateSettingsMutation = useMutation({
     mutationFn: (nextSocials: Record<string, string>) =>
@@ -66,7 +67,7 @@ export const EbayDataPanel = () => {
     },
   });
 
-  const setFlag = (key: '_ff_ebaySoldAvg' | '_ff_ebaySoldAvgAdminOnly' | '_ff_ebayManualSync', value: boolean) => {
+  const setFlag = (key: '_ff_ebaySoldAvg' | '_ff_ebaySoldAvgAdminOnly' | '_ff_ebayManualSync' | '_ff_ebayItemCardButtonPublic', value: boolean) => {
     const baseSocials = (cardcadeSettings?.socials ?? {}) as Record<string, string>;
     const nextSocials: Record<string, string> = {
       ...baseSocials,
@@ -98,9 +99,9 @@ export const EbayDataPanel = () => {
     queryKey: ['migration-status', migrationJobId],
     queryFn: () => api.admin.getMigratePsaGradeFlagsStatus(migrationJobId!),
     enabled: !!migrationJobId,
-    refetchInterval: (data) => {
+    refetchInterval: (query) => {
       // Stop polling if completed or failed
-      if (data?.state === 'completed' || data?.state === 'failed') {
+      if (query.state.data?.state === 'completed' || query.state.data?.state === 'failed') {
         return false;
       }
       return 2000; // Poll every 2 seconds
@@ -165,6 +166,20 @@ export const EbayDataPanel = () => {
               <Switch
                 checked={ebaySoldAvgAdminOnly}
                 onCheckedChange={(checked) => setFlag('_ff_ebaySoldAvgAdminOnly', checked)}
+                disabled={updateSettingsMutation.isPending}
+              />
+            </div>
+
+            <div className="flex items-center justify-between rounded-md border p-3">
+              <div className="space-y-1 pr-3">
+                <Label className="text-sm font-medium">Show eBay Button on Item Cards for Users</Label>
+                <p className="text-xs text-muted-foreground">
+                  When enabled, regular users can see the "See Recent eBay Sales" button on shop/redemption item cards. Auction cards always show the button for everyone.
+                </p>
+              </div>
+              <Switch
+                checked={ebayItemCardButtonPublic}
+                onCheckedChange={(checked) => setFlag('_ff_ebayItemCardButtonPublic', checked)}
                 disabled={updateSettingsMutation.isPending}
               />
             </div>

--- a/src/components/prizes/PrizeCard.tsx
+++ b/src/components/prizes/PrizeCard.tsx
@@ -391,11 +391,13 @@ export default function PrizeCard({
   const ebaySoldAvgEnabled = ebayFeatureFlagsQuery.data?.ebaySoldAvgEnabled ?? true;
   const ebaySoldAvgAdminOnly = ebayFeatureFlagsQuery.data?.ebaySoldAvgAdminOnly ?? false;
   const ebayManualSyncEnabled = ebayFeatureFlagsQuery.data?.ebayManualSyncEnabled ?? true;
+  const ebayItemCardButtonPublic = ebayFeatureFlagsQuery.data?.ebayItemCardButtonPublic ?? false;
 
   // Determine if eBay box should render (for layout consistency)
+  // For item cards (non-auction), users need the itemCardButtonPublic flag enabled
   const shouldShowEbayBox = isAdminUser
     ? ebaySoldAvgEnabled
-    : (ebaySoldAvgEnabled && !ebaySoldAvgAdminOnly);
+    : (ebaySoldAvgEnabled && !ebaySoldAvgAdminOnly && ebayItemCardButtonPublic);
 
   // Early-access countdown: only for items with a timed window (not permanently pro-only)
   const earlyAccessDate = !prize.isProOnly ? prize.proEarlyAccessUntil : null;

--- a/src/integrations/api/client.ts
+++ b/src/integrations/api/client.ts
@@ -1583,6 +1583,7 @@ export const prizeAPI = {
     ebaySoldAvgEnabled: boolean;
     ebaySoldAvgAdminOnly: boolean;
     ebayManualSyncEnabled: boolean;
+    ebayItemCardButtonPublic: boolean;
   }> => {
     const response = await apiClient.get('/prizes/ebay-feature-flags');
     return response.data;

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -79,15 +79,15 @@ const Leaderboard = () => {
                   >
                     selling
                   </Link>
-                  , and spinning the{' '}
+                  , and {' '}
                   <Link 
                     to="/daily-spin" 
                     className="underline hover:no-underline transition-all"
                     style={{ color: 'var(--electric-lime)', textShadow: '0 0 5px rgba(189, 255, 0, 0.3)' }}
                   >
-                    daily spin
+                    spinning
                   </Link>
-                  ! Then go over to{' '}
+                  ! Then go to{' '}
                   <Link 
                     to="/redemptions" 
                     className="underline hover:no-underline transition-all"
@@ -95,7 +95,7 @@ const Leaderboard = () => {
                   >
                     Prizes
                   </Link>
-                  {' '}to redeem! We also do a monthly giveaway for the highest coin earner of the month
+                  {' '}to redeem! We also do monthly giveaways for the highest coin earner of the month
                 </p>
               </div>
             </div>

--- a/src/pages/Redemptions.tsx
+++ b/src/pages/Redemptions.tsx
@@ -176,7 +176,7 @@ export default function Redemptions() {
               <h3 className="text-lg font-semibold text-white">How Prizes Work</h3>
               <div className="space-y-2 text-sm text-[#FFFFFFBF]">
                 <p>
-                  Congrats! You've earned Cadecoins.
+                  Congrats! You've earned Cadecoins!
                 </p>
                 <p>
                   Redeem them here for cards and sealed product, and we'll get them shipped out STAT!


### PR DESCRIPTION
This pull request introduces a new feature flag to control the visibility of the "See Recent eBay Sales" button for regular users on item cards, along with minor improvements to user-facing text. The changes primarily focus on making the eBay sales button configurable via admin settings and ensuring the frontend respects this setting.

**Feature flag and eBay button visibility:**

* Added a new feature flag, `_ff_ebayItemCardButtonPublic`, to control whether regular users can see the "See Recent eBay Sales" button on shop/redemption item cards (auction cards are unaffected). The flag is now available in admin settings (`EbayDataPanel`) and is included in the API response for eBay feature flags. [[1]](diffhunk://#diff-b6a3ee5f96e4ef7757f3208f9308a0980fc081b6c2a534a733eddcb487ae77ecR49) [[2]](diffhunk://#diff-b6a3ee5f96e4ef7757f3208f9308a0980fc081b6c2a534a733eddcb487ae77ecL69-R70) [[3]](diffhunk://#diff-5da9525b80e737f8309b545d662efffd75ca1dfaa50ab3695364b081c8460173R1586) [[4]](diffhunk://#diff-b6a3ee5f96e4ef7757f3208f9308a0980fc081b6c2a534a733eddcb487ae77ecR173-R186)
* Updated `PrizeCard` logic so that non-admin users only see the eBay sales button if the new feature flag is enabled, in addition to the existing conditions.

**Minor text improvements:**

* Improved phrasing and punctuation in the instructions on the Leaderboard and Redemptions pages for better clarity and readability. [[1]](diffhunk://#diff-c39a19a3d08c7cc550d8ec0a9d952bb6c3809aefb49b4312fbffdb5bf9c5119dL82-R98) [[2]](diffhunk://#diff-d19b9e19e9527c673c2a3e9240700e67b4b2bfab94dfee34217f436b0ab877b7L179-R179)

**Other:**

* Updated the polling logic in `EbayDataPanel` to use the correct query object structure for determining when to stop polling the migration status.